### PR TITLE
Fix some issues with the externalip-webhook chart

### DIFF
--- a/charts/externalip-webhook-1.0.0/templates/deployment.yaml
+++ b/charts/externalip-webhook-1.0.0/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "externalip-webhook.fullname" . }}
+  name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "externalip-webhook.labels" . | nindent 4 }}
@@ -41,10 +41,6 @@ spec:
             - name: webhook-server
               containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
-          livenessProbe:
-            {{- toYaml .Values.livenessProbe | nindent 12 }}
-          readinessProbe:
-            {{- toYaml .Values.readinessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
@@ -58,7 +54,7 @@ spec:
         - name: cert
           secret:
             defaultMode: 420
-            secretName: {{ include "externalip-webhook.fullname" . }}
+            secretName: {{ .Release.Name }}
       {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/externalip-webhook-1.0.0/templates/secret.yaml
+++ b/charts/externalip-webhook-1.0.0/templates/secret.yaml
@@ -1,9 +1,11 @@
+{{- if .Values.createSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "externalip-webhook.fullname" . }}
+  name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
 data:
   ca.crt: {{ .Values.caCert }}
   tls.crt: {{ .Values.tlsCert }}
   tls.key: {{ .Values.tlsKey }}
+{{ end -}}

--- a/charts/externalip-webhook-1.0.0/templates/service.yaml
+++ b/charts/externalip-webhook-1.0.0/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "externalip-webhook.fullname" . }}
+  name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "externalip-webhook.labels" . | nindent 4 }}

--- a/charts/externalip-webhook-1.0.0/templates/webhook.yaml
+++ b/charts/externalip-webhook-1.0.0/templates/webhook.yaml
@@ -1,17 +1,17 @@
-apiVersion: admissionregistration.k8s.io/{{ .AdmissionRegistrationApiVersion }}
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   creationTimestamp: null
-  name: {{ include "externalip-webhook.fullname" . }}
+  name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
 webhooks:
 - clientConfig:
     caBundle: '{{ .Values.caCert }}'
     service:
-      name: {{ include "externalip-webhook.fullname" . }}
+      name: {{ .Release.Name }}
       namespace: {{ .Release.Namespace }}
       path: /validate-service
-  failurePolicy: Ignore
+  failurePolicy: Fail
   name: validate-externalip.webhook.svc
   rules:
   - apiGroups:
@@ -23,5 +23,6 @@ webhooks:
     - UPDATE
     resources:
     - services
-  {{ .SideEffects }}
-  {{ .AdmissionReviewVersions }}
+  sideEffects: None
+  admissionReviewVersions:
+  - v1beta1

--- a/charts/externalip-webhook-1.0.0/values.yaml
+++ b/charts/externalip-webhook-1.0.0/values.yaml
@@ -30,12 +30,30 @@ securityContext: {}
 
 service:
   type: ClusterIP
-  port: 80
+  port: 443
   targetPort: 9443
 
+# If set to true, the PKI secret is created when installing the application.
+# It uses the values of .caCert, .tlsCert, and .tlsKey to populate the secret.
+# Be aware that allowing the chart to create the secret will place the key
+# values in the Helm release secret.
+#
+# If the value is false, the application will use a manually created secret.
+# While it is not necessary to create the secret prior to installing the chart,
+# the webhook pods will not start until the secret is available.
+createSecret: false
+
+# The public certificate for the certififcate authority that signed the
+# certificate configured with .tlsCert and .tlsKey.  It must be base 64 encoded.
+# This value is required even if .createSecret is false.
 caCert: ""
+
+# The public certificate and private key for the webhook service.  It must be
+# base 64 encoded.  These values are optional if .createSecret  is false.
 tlsCert: ""
 tlsKey: ""
+
+# A comma separated list of CIDR blocks to allow.
 allowedCidrs: ""
 
 resources: {}
@@ -49,15 +67,6 @@ resources: {}
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
-
-livenessProbe:
-  httpGet:
-    path: /
-    port: http
-readinessProbe:
-  httpGet:
-    path: /
-    port: http
 
 # Additional volumes on the output Deployment definition.
 volumes: []


### PR DESCRIPTION
The externalip-webhook chart had a couple problems and a few gross things.  The following things are addressed:
- invalid ValidatingWebhookConfiguration
- fixed up some defaults so that fewer values are required
- added some documentation for important fields
- added a value that allows for a user-deployed certificate secret
- shortened some resource names to make it easier to manage secrets and the like

The values file used here contains the certificates and allowed CIDR block list.
```
$ ./out/linux_amd64/ocne application install -c embedded -n externalip-validation-system -r externalip-validation-webhook-service -N externalip-webhook --values externalip-values.yaml 
INFO[2024-10-01T18:50:38Z] Application installed successfully    

$ kubectl -n externalip-validation-system edit svc externalip-validation-webhook-service 
error: services "externalip-validation-webhook-service" could not be patched: admission webhook "validate-externalip.webhook.svc" denied the request: spec.externalIPs: Invalid value: "123.45.67.89": externalIP specified is not allowed to use
You can run `kubectl replace -f /tmp/kubectl-edit-1933896803.yaml` to try this update again.
```