### PR TITLE
Add Fluentd 1.14.5 to the app-catalog

### DIFF
--- a/charts/fluentd-1.14.5/.helmignore
+++ b/charts/fluentd-1.14.5/.helmignore
@@ -1,0 +1,5 @@
+test
+*.txt
+.gitignore
+.idea
+.git

--- a/charts/fluentd-1.14.5/Chart.yaml
+++ b/charts/fluentd-1.14.5/Chart.yaml
@@ -1,0 +1,6 @@
+deprecated: true
+apiVersion: v1
+description: A Helm chart for Verrazzano Fluentd
+name: fluentd
+version: 1.14.5
+appVersion: 1.14.5

--- a/charts/fluentd-1.14.5/Chart.yaml
+++ b/charts/fluentd-1.14.5/Chart.yaml
@@ -1,6 +1,6 @@
-deprecated: true
 apiVersion: v1
-description: A Helm chart for Verrazzano Fluentd
+deprecated: true
+description: DEPRECATED A Helm chart for Verrazzano Fluentd
 name: fluentd
 version: 1.14.5
 appVersion: 1.14.5

--- a/charts/fluentd-1.14.5/Chart.yaml
+++ b/charts/fluentd-1.14.5/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 deprecated: true
-description: DEPRECATED A Helm chart for Verrazzano Fluentd
+description: DEPRECATED A Helm chart for Fluentd
 name: fluentd
 version: 1.14.5
 appVersion: 1.14.5

--- a/charts/fluentd-1.14.5/NOTES.txt
+++ b/charts/fluentd-1.14.5/NOTES.txt
@@ -1,0 +1,1 @@
+Verrazzano Fluentd Helm chart has been installed!

--- a/charts/fluentd-1.14.5/NOTES.txt
+++ b/charts/fluentd-1.14.5/NOTES.txt
@@ -1,1 +1,0 @@
-Verrazzano Fluentd Helm chart has been installed!

--- a/charts/fluentd-1.14.5/templates/clusterrole.yaml
+++ b/charts/fluentd-1.14.5/templates/clusterrole.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.logging.name }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - pods
+    verbs:
+      - get
+      - list
+      - watch

--- a/charts/fluentd-1.14.5/templates/clusterrolebinding.yaml
+++ b/charts/fluentd-1.14.5/templates/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.logging.name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.logging.name }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Values.logging.name }}
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/fluentd-1.14.5/templates/daemonset.yaml
+++ b/charts/fluentd-1.14.5/templates/daemonset.yaml
@@ -1,0 +1,184 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ .Values.logging.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: fluentd
+spec:
+  selector:
+    matchLabels:
+      app: fluentd
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
+      labels:
+        app: fluentd
+    spec:
+      initContainers:
+        - name: cacert-init
+          command: ["/init/init.sh"]
+          image: {{ .Values.logging.fluentdImage }}
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 999
+            runAsGroup: 997
+            privileged: false
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - mountPath: /init
+              name: {{ .Values.logging.name }}-init
+              readOnly: true
+            - name: cacerts
+              mountPath: /fluentd/cacerts
+            - mountPath: /fluentd/secret
+              name: secret-volume
+              readOnly: true
+      containers:
+        - args:
+            - -c
+            - /etc/fluentd.conf
+          env:
+            - name: FLUENTD_CONF
+              value: fluentd-standalone.conf
+            - name: FLUENT_ELASTICSEARCH_SED_DISABLE
+              value: "true"
+            - name: ELASTICSEARCH_URL
+              value: {{ .Values.logging.osURL }}
+            - name: CLUSTER_NAME
+              value: {{ .Values.logging.clusterName }}
+            - name: ELASTICSEARCH_USER
+              valueFrom:
+                secretKeyRef:
+                  key: {{ .Values.logging.usernameKey }}
+                  name: {{ .Values.logging.credentialsSecret }}
+                  optional: true
+            - name: ELASTICSEARCH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: {{ .Values.logging.passwordKey }}
+                  name: {{ .Values.logging.credentialsSecret }}
+                  optional: true
+            - name: CA_FILE
+              value: /fluentd/cacerts/all-ca-certs.pem
+            - name: CONFIG_HASH
+{{- if .Values.logging.configHash }}
+              value: {{ .Values.logging.configHash }}
+{{- else }}
+              value: none
+{{- end }}
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          image: {{ .Values.logging.fluentdImage }}
+          imagePullPolicy: IfNotPresent
+          securityContext:
+{{- if .Values.seLinuxOptions }}
+            seLinuxOptions:
+              type: {{ .Values.seLinuxOptions.type }}
+              level: {{ .Values.seLinuxOptions.level }}
+              role: {{ .Values.seLinuxOptions.role }}
+              user: {{ .Values.seLinuxOptions.user }}
+{{- end }}
+            privileged: false
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - DAC_OVERRIDE
+          ports:
+          - containerPort: 24231
+            name: http-metrics
+            protocol: TCP
+          name: {{ .Values.logging.name }}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - name: cacerts
+              mountPath: /fluentd/cacerts
+            - mountPath: /fluentd/secret
+              name: secret-volume
+              readOnly: true
+  {{- if .Values.fluentd.oci }}
+  {{- if .Values.fluentd.oci.apiSecret }}
+            - mountPath: /root/.oci
+              name: oci-secret-volume
+              readOnly: true
+  {{- end }}
+  {{- end }}
+            - mountPath: /fluentd/etc
+              name: {{ .Values.logging.name }}-config
+              readOnly: true
+            - mountPath: /var/log
+              name: varlog
+              readOnly: false
+            - mountPath: /var/lib
+              name: varlib
+              readOnly: true
+            - mountPath: /run/log/journal
+              name: run-log-journal
+              readOnly: true
+{{- if .Values.fluentd.extraVolumeMounts }}
+{{- range $i, $e := .Values.fluentd.extraVolumeMounts }}
+            - mountPath: {{ $e.destination }}
+              name: extra-volume-{{ $i }}
+              readOnly: {{ $e.readOnly }}
+{{- end }}
+{{- end }}
+      serviceAccountName: fluentd
+      terminationGracePeriodSeconds: 30
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      volumes:
+        - configMap:
+            defaultMode: 0755
+            name: {{ .Values.logging.name }}-init
+          name: {{ .Values.logging.name }}-init
+        - name: cacerts
+          emptyDir: {}
+        - name: secret-volume
+          secret:
+            secretName: {{ .Values.logging.credentialsSecret }}
+            optional: true
+  {{- if .Values.fluentd.oci }}
+  {{- if .Values.fluentd.oci.apiSecret }}
+        - name: oci-secret-volume
+          secret:
+            secretName: {{ .Values.fluentd.oci.apiSecret }}
+  {{- end }}
+  {{- end }}
+        - configMap:
+            name: {{ .Values.logging.name }}-config
+          name: {{ .Values.logging.name }}-config
+        - hostPath:
+            path: /var/log
+            type: ""
+          name: varlog
+        - hostPath:
+            path: /var/lib
+            type: ""
+          name: varlib
+        - hostPath:
+            path: /run/log/journal
+            type: ""
+          name: run-log-journal
+{{- if .Values.fluentd.extraVolumeMounts }}
+{{- range $i, $e := .Values.fluentd.extraVolumeMounts }}
+        - hostPath:
+            path: {{ $e.source }}
+            type: ""
+          name: extra-volume-{{ $i }}
+{{- end }}
+{{- end }}
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate

--- a/charts/fluentd-1.14.5/templates/fluentd-config-configmap.yaml
+++ b/charts/fluentd-1.14.5/templates/fluentd-config-configmap.yaml
@@ -1,0 +1,1178 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.logging.name }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.logging.name }}
+data:
+  fluent.conf: |
+    # Use the config specified by the FLUENTD_CONFIG environment variable, or
+    # default to fluentd-standalone.conf
+    @include "#{ENV['FLUENTD_CONFIG'] || 'fluentd-standalone.conf'}"
+
+  # A config for running Fluentd as a daemon which collects, filters, parses,
+  # and sends log to storage. No extra Fluentd processes required.
+  fluentd-standalone.conf: |
+    # Common config
+    @include general.conf
+    @include prometheus.conf
+
+    # Input sources
+    @include systemd-input.conf
+    @include kubernetes-input.conf
+
+    # Parsing/Filtering
+    @include systemd-filter.conf
+    @include kubernetes-filter.conf
+    @include components-filter.conf
+
+    # Send to storage
+    @include output.conf
+    {{- if .Values.fluentd.oci }}
+    # Start namespace logging configs
+    # End namespace logging configs
+    {{- if .Values.fluentd.oci.systemLogId }}
+    @include oci-logging-system.conf
+    {{- if .Values.fluentd.oci.defaultAppLogId }}
+    @include oci-logging-default-app.conf
+    {{- end }}
+    {{- end }}
+    {{- else }}
+    @include es-output.conf
+    {{- end }}
+
+  general.conf: |
+    # Prevent Fluentd from handling records containing its own logs. Otherwise
+    # it can lead to an infinite loop, when error in sending one message generates
+    # another message which also fails to be sent and so on.
+    <label @FLUENT_LOG>
+      <match fluent.*>
+        @type null
+      </match>
+    </label>
+
+    # Used for health checking
+    <source>
+      @type http
+      @id in_http
+      port 9880
+      bind 0.0.0.0
+    </source>
+
+    # Emits internal metrics to every minute, and also exposes them on port
+    # 24220. Useful for determining if an output plugin is retrying/erroring,
+    # or determining the buffer queue length.
+    <source>
+      @type monitor_agent
+      @id in_monitor_agent
+      bind 0.0.0.0
+      port 24220
+    </source>
+
+  prometheus.conf: |
+    # Prometheus Exporter Plugin
+    # input plugin that exports metrics
+    <source>
+      @type prometheus
+      port 24231
+      metrics_path /metrics
+    </source>
+    # input plugin that collects metrics from MonitorAgent
+    <source>
+      @type prometheus_monitor
+      <labels>
+        host ${hostname}
+      </labels>
+    </source>
+    # input plugin that collects metrics for output plugin
+    <source>
+      @type prometheus_output_monitor
+      <labels>
+        host ${hostname}
+      </labels>
+    </source>
+    # input plugin that collects metrics for in_tail plugin
+    <source>
+      @type prometheus_tail_monitor
+      <labels>
+        host ${hostname}
+      </labels>
+    </source>
+
+  systemd-input.conf: |
+    <source>
+      @type systemd
+      @id in_systemd_run
+      read_from_head true
+      tag systemd
+      path /run/log/journal
+      <storage>
+        @type local
+        persistent true
+        path /tmp/run_journald_pos.json
+      </storage>
+      <entry>
+        fields_strip_underscores true
+      </entry>
+    </source>
+
+  systemd-filter.conf: |
+    <filter systemd>
+       @type record_transformer
+       @id systemd_index
+       <record>
+          tag systemd
+       </record>
+    </filter>
+
+    <filter systemd.kubelet>
+      @type parser
+      @id systemd_kubelet_parser
+      format kubernetes
+      reserve_data true
+      key_name MESSAGE
+    </filter>
+
+    <filter systemd.docker>
+      @type parser
+      @id systemd_docker_parser
+      format /^time="(?<time>[^)]*)" level=(?<severity>[^ ]*) msg="(?<message>[^"]*)"( err="(?<error>[^"]*)")?( statusCode=($<status_code>\d+))?/
+      reserve_data true
+      key_name MESSAGE
+    </filter>
+
+    # Filter ssh logs since it's mostly bots trying to login
+    <filter systemd.**>
+      @type grep
+      @id systemd_grep
+      <exclude>
+        key SYSTEMD_UNIT
+        pattern (sshd@.*\.service)
+      </exclude>
+    </filter>
+
+  kubernetes-input.conf: |
+    # Capture Kubernetes pod logs
+    # The kubelet creates symlinks that capture the pod name, namespace,
+    # container name & Docker container ID to the docker logs for pods in the
+    # /var/log/containers directory on the host.
+    <source>
+      @type tail
+      # @id in_tail
+      path /var/log/containers/*.log
+      pos_file /var/log/vz-fluentd-containers.log.pos
+      # Exclude the log of the Fluentd daemonset itself
+      exclude_path ["/var/log/containers/fluentd*_verrazzano-system_fluentd*.log"]
+      tag kubernetes.*
+      read_from_head true
+      # @log_level debug
+      <parse>
+        @type multi_format
+        <pattern>
+          format json
+          time_format %Y-%m-%dT%H:%M:%S.%NZ
+        </pattern>
+        # KIND CRI pattern/format
+        <pattern>
+          format /^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<flags>[^ ]+) (?<log>.*)$/
+          time_format %Y-%m-%dT%H:%M:%S.%NZ
+        </pattern>
+        # OKE v1.20.8
+        <pattern>
+          format /^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<flags>[^ ]+) (?<log>.*)$/
+          time_format %Y-%m-%dT%H:%M:%S.%N%:z
+        </pattern>
+      </parse>
+    </source>
+
+  components-filter.conf: |
+    # filter to parse istio-proxy and istiod container log files
+    <filter kubernetes.**istio-proxy** kubernetes.**istiod**istio-system_discovery**>
+      @type parser
+      @id istio
+      key_name log
+      reserve_data true
+      emit_invalid_record_to_error true
+      <parse>
+        # istio containers have two formats for log records
+        # one has a timestamp, log level and other fields
+        # the other is just a messsage
+        @type multi_format
+        <pattern>
+          format /^(?<logtime>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}Z)\t(?<level>.*?)\t(?<message>[\s\S]*?)$/
+          time_key logtime
+          time_format %Y-%m-%dT%H:%M:%S.%NZ
+        </pattern>
+        <pattern>
+          format none
+        </pattern>
+      </parse>
+    </filter>
+
+    # filter to parse opensearch log files which includes es-master, es-data, es-ingest
+    <filter kubernetes.**vmi-system-es-**verrazzano-system_es-**>
+      @type parser
+      @id opensearch
+      key_name log
+      reserve_data true
+      emit_invalid_record_to_error true
+      <parse>
+        # opensearch have two formats for log records
+        # one has a timestamp, log level and message (already been parsed under istio-proxy container)
+        # the other is timestamp, log level, other field, pod-name and message
+        @type multi_format
+        <pattern>
+          format /^\[(?<logtime>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2},\d{3})\]\[(?<level>.*?)\]\[.*vmi-system-es-.*?\]\s(?<message>.*?)$/
+          time_key logtime
+          time_format %Y-%m-%dT%H:%M:%S,%N
+        </pattern>
+        <pattern>
+          format none
+        </pattern>
+      </parse>
+    </filter>
+
+    # filter to parse authproxy container log files
+    <filter kubernetes.**verrazzano-authproxy**verrazzano-authproxy**>
+      @type parser
+      @id authproxy
+      key_name log
+      reserve_data true
+      emit_invalid_record_to_error true
+      <parse>
+        # authproxy has two formats for log records
+        # one has a timestamp, log level and other fields
+        # the other is just a messsage
+        @type multi_format
+        <pattern>
+          format json
+          time_key @timestamp
+          time_format %Y-%m-%dT%H:%M:%S+%N
+        </pattern>
+        <pattern>
+          format none
+        </pattern>
+      </parse>
+    </filter>
+
+    # filter to parse kiali container log files
+    <filter kubernetes.**vmi-system-kiali**verrazzano-system_vmi-system-kiali**>
+      @type parser
+      @id vmi-system-kiali
+      key_name log
+      reserve_data true
+      emit_invalid_record_to_error true
+      <parse>
+        # Kiali has two formats for log records
+        # Kiali format and a klog format
+        @type multi_format
+        <pattern>
+          format /^(?<logtime>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z) (?<level>.*?) (?<message>[\s\S]*?)$/
+          time_key logtime
+          time_format %Y-%m-%dT%H:%M:%SZ
+        </pattern>
+        <pattern>
+          format /^(?<level>.)(\d{2}\d{2}) (?<logtime>\d{2}:\d{2}:\d{2}.\d{6})\s*?(?<message>[\s\S]*?)$/
+          time_key logtime
+          time_format %H:%M:%S.%N
+        </pattern>
+        <pattern>
+          format none
+        </pattern>
+      </parse>
+    </filter>
+
+    # filter to parse Coherence operator container log files
+    <filter kubernetes.**coherence-operator**verrazzano-system_manager**>
+      @type parser
+      @id coh-operator
+      key_name log
+      reserve_data true
+      emit_invalid_record_to_error true
+      <parse>
+        # Coherence operator has two formats for log records
+        # Coherence operator format and a klog format
+        @type multi_format
+        <pattern>
+          format /^(?<logtime>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z)\t(?<level>.*?)\t(?<message>[\s\S]*?)$/
+          time_key logtime
+          time_format %Y-%m-%dT%H:%M:%S.%NZ
+        </pattern>
+        <pattern>
+          format /^(?<level>.)(\d{2}\d{2}) (?<logtime>\d{2}:\d{2}:\d{2}.\d{6})\s*?(?<message>[\s\S]*?)$/
+          time_key logtime
+          time_format %H:%M:%S.%N
+        </pattern>
+        <pattern>
+          format none
+        </pattern>
+      </parse>
+    </filter>
+
+    # filter to parse oam-kubernetes-runtime container log files
+    <filter kubernetes.**oam-kubernetes-runtime**verrazzano-system_oam-kubernetes-runtime**>
+      @type parser
+      @id oam-kubernetes-runtime
+      key_name log
+      reserve_data true
+      emit_invalid_record_to_error true
+      <parse>
+        # oam-kubernetes-runtime has two formats for log records
+        # oam-kubernetes-runtime format and a klog format
+        @type multi_format
+        <pattern>
+          format /^(?<logtime>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z)\t(?<level>.*?)\t(?<message>[\s\S]*?)$/
+          time_key logtime
+          time_format %Y-%m-%dT%H:%M:%S.%NZ
+        </pattern>
+        <pattern>
+          format /^(?<level>.)(\d{2}\d{2}) (?<logtime>\d{2}:\d{2}:\d{2}.\d{6})\s*?(?<message>[\s\S]*?)$/
+          time_key logtime
+          time_format %H:%M:%S.%N
+        </pattern>
+        <pattern>
+          format none
+        </pattern>
+      </parse>
+    </filter>
+
+    # filter to parse cert-manager container log files
+    # includes cert-manager, ca-injector, webhook
+    <filter kubernetes.**cert-manager**cert-manager**>
+      @type parser
+      @id cert-manager
+      key_name log
+      reserve_data true
+      emit_invalid_record_to_error true
+      <parse>
+        # cert-manager has a klog format
+        @type multi_format
+        <pattern>
+          format /^(?<level>.)(\d{2}\d{2}) (?<logtime>\d{2}:\d{2}:\d{2}.\d{6})\s*?(?<message>[\s\S]*?)$/
+          time_key logtime
+          time_format %H:%M:%S.%N
+        </pattern>
+        <pattern>
+          format none
+        </pattern>
+      </parse>
+    </filter>
+
+    # filter to parse Verrazzano platform operator container log files
+    <filter kubernetes.**verrazzano-**-operator** kubernetes.**verrazzano-**_webhook-init**>
+      @type parser
+      @id verrazzano-operators
+      key_name log
+      reserve_data true
+      emit_invalid_record_to_error true
+      <parse>
+        @type multi_format
+        <pattern>
+          format json
+          time_key @timestamp
+          time_format %Y-%m-%dT%H:%M:%S.%NZ
+        </pattern>
+        # Kubernetes klog format
+        <pattern>
+          format /^(?<level>.)(\d{2}\d{2}) (?<logtime>\d{2}:\d{2}:\d{2}.\d{6})\s*?(?<message>[\s\S]*?)$/
+          time_key logtime
+          time_format %H:%M:%S.%N
+        </pattern>
+        <pattern>
+          format none
+        </pattern>
+      </parse>
+    </filter>
+
+    # filter to parse Keycloak container log files
+    <filter kubernetes.**keycloak**keycloak_keycloak**>
+      @type parser
+      @id keycloak
+      key_name log
+      reserve_data true
+      emit_invalid_record_to_error true
+      <parse>
+        # Keycloak has one format for log records
+        @type multi_format
+        <pattern>
+          format /^.*?(?<logtime>\d{2}:\d{2}:\d{2},\d{3}) (?<level>.*?)( |\t)+\[.*?\]( |\t)+\(.*?\)( |\t)+(?<message>.*)$/
+          time_key logtime
+          time_format %H:%M:%S,%N
+        </pattern>
+        <pattern>
+          format none
+        </pattern>
+      </parse>
+    </filter>
+
+    # filter to parse MySQL container log files
+    <filter kubernetes.**mysql**keycloak_mysql**>
+      @type parser
+      @id mysql
+      key_name log
+      reserve_data true
+      emit_invalid_record_to_error true
+      <parse>
+        # MySQL has two formats for log records
+        @type multi_format
+        <pattern>
+          format /^(?<logtime>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}Z) \d+ \[(?<level>.*?)\] (\[.*?\] ){2}(?<message>.*?)$/
+          time_key logtime
+          time_format %Y-%m-%dT%H:%M:%S.%NZ
+        </pattern>
+        <pattern>
+          format /^(?<logtime>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})\+\d{2}:\d{2} \[(?<level>.*?)\] \[.*?\]: (?<message>.*?)$/
+          time_key logtime
+          time_format %Y-%m-%d %H:%M:%S
+        </pattern>
+        <pattern>
+          format none
+        </pattern>
+      </parse>
+    </filter>
+
+    # filter to parse MySQLOperator container log files
+    <filter kubernetes.**mysql-operator**mysql-operator_mysql-operator**>
+      @type parser
+      @id mysql-operator
+      key_name log
+      reserve_data true
+      emit_invalid_record_to_error true
+      <parse>
+        @type multi_format
+        <pattern>
+          format /^\[(?<logtime>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3})\]\s(?<component>.*?)\s\[(?<level>.*?)\]\s(?<message>.*?)$/
+          time_key logtime
+          time_format %Y-%m-%d %H:%M:%S,%N
+        </pattern>
+        <pattern>
+          format /^(?<logtime>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}):\s(?<level>.*?):\s(?<message>.*?)$/
+          time_key logtime
+          time_format %Y-%m-%d %H:%M:%S
+        </pattern>
+        <pattern>
+          format none
+        </pattern>
+      </parse>
+    </filter>
+
+    # filter to parse Grafana container log files
+    <filter kubernetes.**vmi-system-grafana**verrazzano-system_grafana**>
+      @type parser
+      @id grafana
+      key_name log
+      reserve_data true
+      emit_invalid_record_to_error true
+      <parse>
+        # Grafana has two formats for log records
+        # one for json logs and one for string logs
+        @type multi_format
+        <pattern>
+          format json
+          time_key @timestamp
+          time_format %Y-%m-%dT%H:%M:%S.%NZ
+        </pattern>
+        <pattern>
+          format /^t=(?<logtime>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})\+\d{4} lvl=(?<level>\S+) msg="(?<message>.*?)".*?$/
+          time_key logtime
+          time_format %Y-%m-%dT%H:%M:%S
+        </pattern>
+        <pattern>
+          format none
+        </pattern>
+      </parse>
+    </filter>
+
+    # filter to apply a record transformer Grafana container log files in JSON format
+    <filter kubernetes.**vmi-system-grafana**verrazzano-system_grafana**>
+      @type record_transformer
+      @id grafana-json
+      enable_ruby true
+      <record>
+        message ${record["@message"] ? record["@message"] : record["message"] ? record["message"] : ""}
+        level ${record["@level"] ? record["@level"] : record["level"] ? record["level"] : ""}
+      </record>
+    </filter>
+
+
+    # filter to parse verrazzano-system Prometheus container log files
+    <filter kubernetes.**vmi-system-prometheus**verrazzano-system_prometheus**>
+      @type parser
+      @id vmi-system-prometheus
+      key_name log
+      reserve_data true
+      emit_invalid_record_to_error true
+      <parse>
+        # Prometheus has two formats for log records
+        # One with a level and msg
+        # One with a level but not msg
+        @type multi_format
+        <pattern>
+          format /^ts=(?<logtime>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z)(.*)level=(?<level>.*?) (.*?)msg="(?<message>.*?)"([\s\S]*?)$/
+          time_key logtime
+          time_format %Y-%m-%dT%H:%M:%S.%NZ
+        </pattern>
+        <pattern>
+          format /^ts=(?<logtime>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z)(.*)level=(?<level>.*?) (?<message>[\s\S]*?)$/
+          time_key logtime
+          time_format %Y-%m-%dT%H:%M:%S.%NZ
+        </pattern>
+        # Kubernetes klog format
+        <pattern>
+          format /^(?<level>.)(\d{2}\d{2}) (?<logtime>\d{2}:\d{2}:\d{2}.\d{6})\s*?(?<message>[\s\S]*?)$/
+          time_key logtime
+          time_format %H:%M:%S.%N
+        </pattern>
+        <pattern>
+          format none
+        </pattern>
+      </parse>
+    </filter>
+
+    # filter to parse verrazzano-system Prometheus config-reloader container log files
+    <filter kubernetes.**vmi-system-prometheus**verrazzano-system_config-reloader**>
+      @type parser
+      @id config-reloader
+      key_name log
+      reserve_data true
+      emit_invalid_record_to_error true
+      <parse>
+        # config-reloader log messages do not have a log level
+        @type multi_format
+        <pattern>
+          format /^(?<logtime>\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2}) (?<message>[\s\S]*?)$/
+          time_key logtime
+          time_format %Y/%m/%d %H:%M:%S
+        </pattern>
+        <pattern>
+          format none
+        </pattern>
+      </parse>
+    </filter>
+
+    # filter to parse Weblogic Operator Dashboard container log files
+    <filter kubernetes.**weblogic-operator**verrazzano-system_weblogic-operator**>
+      @type parser
+      @id weblogic-operator
+      key_name log
+      reserve_data true
+      emit_invalid_record_to_error true
+      <parse>
+        # WebLogic Operator Dashboard has one format for log records
+        @type multi_format
+        <pattern>
+          format json
+          time_key timestamp
+          time_format %Y-%m-%dT%H:%M:%S.%NZ
+        </pattern>
+        <pattern>
+          format none
+        </pattern>
+      </parse>
+    </filter>
+
+    # filter to apply a record transformer into WebLogic Component log files in JSON format
+    <filter kubernetes.**weblogic-operator**verrazzano-system_weblogic-operator**>
+      @type record_transformer
+      @id weblogic-operator-json
+      remove_keys timestamp
+    </filter>
+
+    # filter to parse OpenSearch Dashboard container log files
+    <filter kubernetes.**vmi-system-osd**verrazzano-system_kibana**>
+      @type parser
+      @id kibana
+      key_name log
+      reserve_data true
+      emit_invalid_record_to_error true
+      <parse>
+        # OpenSearch Dashboard has one format for log records
+        @type multi_format
+        <pattern>
+          format json
+          time_key @timestamp
+          time_format %Y-%m-%dT%H:%M:%SZ
+        </pattern>
+        <pattern>
+          format none
+        </pattern>
+      </parse>
+    </filter>
+
+    # filter to parse OpenSearch Dashboard container log files
+    <filter kubernetes.**vmi-system-osd**verrazzano-system_kibana**>
+      @type record_transformer
+      @id kibana-json
+      enable_ruby true
+      <record>
+        # the following Ruby code looks for an intersection between the "tags" values and the log level values
+        # it returns the first intersection value if found or empty string if not
+        level ${!!record["tags"] ? !(['trace', 'debug', 'info', 'warn', 'error', 'fail'] & record["tags"])[0].nil? ? (['trace', 'debug', 'info', 'warn', 'error', 'fail'] & record["tags"])[0] : "" : ""}
+      </record>
+    </filter>
+
+    # filter to parse NGINX Ingress Controller container log files
+    <filter **ingress-nginx-controller**ingress-nginx_controller-**>
+      @type parser
+      @id nginx-ingress-controller
+      key_name log
+      reserve_data true
+      emit_invalid_record_to_error true
+      <parse>
+        @type multi_format
+        <pattern>
+          format json
+          time_key @timestamp
+          time_format %Y-%m-%dT%H:%M:%S+%N
+        </pattern>
+        # Kubernetes klog format
+        <pattern>
+          format /^(?<level>.)(\d{2}\d{2}) (?<logtime>\d{2}:\d{2}:\d{2}.\d{6})\s*?(?<message>[\s\S]*?)$/
+          time_key logtime
+          time_format %H:%M:%S.%N
+        </pattern>
+        <pattern>
+          format none
+        </pattern>
+      </parse>
+    </filter>
+
+    # filter to parse Rancher namespace container log files
+    <filter kubernetes.**cattle-system** kubernetes.**fleet-system** kubernetes.**local-path-provisioner**>
+      @type parser
+      @id rancher
+      key_name log
+      reserve_data true
+      emit_invalid_record_to_error true
+      <parse>
+        @type multi_format
+        # Rancher pattern #1
+        <pattern>
+          format /^time="(?<logtime>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)" level=(?<level>.*?) msg="(?<message>.*?)"[\s\S]*?$/
+          time_key logtime
+          time_format %Y-%m-%dT%H:%M:%SZ
+        </pattern>
+        # Rancher pattern #2
+        <pattern>
+          format /^(?<logtime>\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2}) \[(?<level>.*?)\] (?<message>[\s\S]*?)?$/
+          time_key logtime
+          time_format %Y/%m/%d %H:%M:%S
+        </pattern>
+        # Kubernetes klog format
+        <pattern>
+          format /^(?<level>.)(\d{2}\d{2}) (?<logtime>\d{2}:\d{2}:\d{2}.\d{6})\s*?(?<message>[\s\S]*?)$/
+          time_key logtime
+          time_format %H:%M:%S.%N
+        </pattern>
+        <pattern>
+          format none
+        </pattern>
+      </parse>
+    </filter>
+
+    # filter to parse verrazzano-capi namespace container log files
+    <filter kubernetes.**verrazzano-capi**>
+      @type parser
+      @id clusterapi
+      key_name log
+      reserve_data true
+      emit_invalid_record_to_error true
+      <parse>
+        @type multi_format
+        # Kubernetes klog format
+        <pattern>
+          format /^(?<level>.)(\d{2}\d{2}) (?<logtime>\d{2}:\d{2}:\d{2}.\d{6})\s*?(?<message>[\s\S]*?)$/
+          time_key logtime
+          time_format %H:%M:%S.%N
+        </pattern>
+        <pattern>
+          format none
+        </pattern>
+      </parse>
+    </filter>
+
+    # filter to parse External-dns container log files
+    <filter kubernetes.**external-dns**external-dns**>
+      @type parser
+      @id external-dns
+      key_name log
+      reserve_data true
+      emit_invalid_record_to_error true
+      <parse>
+        @type multi_format
+        # external-dns pattern
+        <pattern>
+          format /^time="(?<logtime>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)" level=(?<level>.*?) msg="(?<message>.*?)"[\s\S]*?$/
+          time_key logtime
+          time_format %Y-%m-%dT%H:%M:%SZ
+        </pattern>
+        # Kubernetes klog format
+        <pattern>
+          format /^(?<level>.)(\d{2}\d{2}) (?<logtime>\d{2}:\d{2}:\d{2}.\d{6})\s*?(?<message>[\s\S]*?)$/
+          time_key logtime
+          time_format %H:%M:%S.%N
+        </pattern>
+        <pattern>
+          format none
+        </pattern>
+      </parse>
+    </filter>
+
+
+    # filter to parse node-exporter container log files
+    <filter kubernetes.**node-exporter**monitoring_node-exporter**>
+      @type parser
+      @id node-exporter
+      key_name log
+      reserve_data true
+      emit_invalid_record_to_error true
+      <parse>
+        # Node exporter has two formats for log records
+        # One with a level and msg
+        # One with a level but not msg
+        @type multi_format
+        <pattern>
+          format /^level=(?<level>.*?) ts=(?<logtime>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z)(.*?)msg="(?<message>.*?)"([\s\S]*?)$/
+          time_key logtime
+          time_format %Y-%m-%dT%H:%M:%S.%NZ
+        </pattern>
+        <pattern>
+          format /^level=(?<level>.*?) ts=(?<logtime>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z) (?<message>[\s\S]*?)$/
+          time_key logtime
+          time_format %Y-%m-%dT%H:%M:%S.%NZ
+        </pattern>
+        <pattern>
+          format none
+        </pattern>
+      </parse>
+    </filter>
+
+    # filter to parse jaeger operator and jaeger resource log files
+    <filter kubernetes.**jaeger-operator-**verrazzano-monitoring_jaeger-**>
+      @type parser
+      @id jaeger
+      key_name log
+      reserve_data true
+      emit_invalid_record_to_error true
+      <parse>
+        @type multi_format
+        # zap log format for Jaeger components
+        <pattern>
+          format json
+          time_key ts
+          time_type float
+        </pattern>
+        # Log patterns for Jaeger operator
+        <pattern>
+          format /^(?<logtime>.*?) (?<level>\S+?) (?<message>[\s\S]*?)$/
+          time_key logtime
+          time_type float
+        </pattern>
+        <pattern>
+          format /^(?<logtime>.*?) (?<level>\S+?) (?<component>[\.\S]+?) (?<message>[\s\S]*?)$/
+          time_key logtime
+          time_type float
+        </pattern>
+        <pattern>
+          format /^time=(?<logtime>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z) level=(?<level>.*?) message=(?<message>[\s\S]*?) error=(?<error>[\s\S]*?) execution=(?<executiontime>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d+ \+\d{3} \w+?) instance=(?<instance>[\s\S]*?) namespace=(?<namespace>[\s\S]*?)$/
+          time_key logtime
+          time_format %Y-%m-%dT%H:%M:%S.%NZ
+        </pattern>
+        <pattern>
+          format none
+        </pattern>
+      </parse>
+    </filter>
+
+    # filter to parse Thanos container log files
+    <filter kubernetes.**thanos**verrazzano-monitoring**>
+      @type parser
+      @id thanos
+      key_name log
+      reserve_data true
+      emit_invalid_record_to_error true
+      <parse>
+        # Thanos has multiple formats for log records
+        # Some records do not have a "msg" field, they instead have an "err" field
+        @type multi_format
+        <pattern>
+          format /^level=(?<level>.*?) ts=(?<logtime>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3,}Z)(.*?)msg="(?<message>.*?)"([\s\S]*?)$/
+          time_key logtime
+          time_format %Y-%m-%dT%H:%M:%S.%NZ
+        </pattern>
+        <pattern>
+          format /^level=(?<level>.*?) ts=(?<logtime>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3,}Z)(.*?)err="(?<message>.*?)"$/
+          time_key logtime
+          time_format %Y-%m-%dT%H:%M:%S.%NZ
+        </pattern>
+        # Istio proxy log pattern
+        <pattern>
+          format /^(?<logtime>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}Z)\t(?<level>.*?)\t(?<message>[\s\S]*?)$/
+          time_key logtime
+          time_format %Y-%m-%dT%H:%M:%S.%NZ
+        </pattern>
+        <pattern>
+          format none
+        </pattern>
+      </parse>
+    </filter>
+
+  kubernetes-filter.conf: |
+    # Query the API for extra metadata.
+    <filter kubernetes.**>
+      @type kubernetes_metadata
+      @id kubernetes_metadata
+      watch_retry_interval 20
+    </filter>
+
+    # rewrite_tag_filter does not support nested fields like
+    # kubernetes.container_name, so this exists to flatten the fields
+    # so we can use them in our rewrite_tag_filter
+    <filter kubernetes.**>
+      @type record_transformer
+      @id kubernetes_record_transformer
+      enable_ruby true
+      <record>
+        kubernetes_namespace_container_name ${record["kubernetes"]["namespace_name"]}.${record["kubernetes"]["container_name"]}
+      </record>
+    </filter>
+
+    # parse sidecar stdout
+    <filter kubernetes.**_fluentd-stdout-sidecar-**>
+      @type parser
+      @id stdout_log_text
+      key_name log
+      reserve_data true
+      emit_invalid_record_to_error true
+      <parse>
+         @type multi_format
+         <pattern>
+           format /^(?<time>[^ ]* [^ ]* [^ ]*) (?<flags>[^\s]+): (?<log>[\s\S]*)$/
+         </pattern>
+         <pattern>
+            format none
+         </pattern>
+      </parse>
+    </filter>
+
+    # parse log record
+    <filter kubernetes.**>
+      @type parser
+      @id parse_log_to_json
+      key_name log
+      reserve_data true
+      emit_invalid_record_to_error true
+      <parse>
+        @type multi_format
+        <pattern>
+          format json
+          time_key @timestamp
+          time_format %Y-%m-%dT%H:%M:%S.%NZ
+        </pattern>
+        <pattern>
+          format none
+        </pattern>
+      </parse>
+    </filter>
+
+    # Remove the unnecessary field as the information is already available on
+    # other fields.
+    <filter kube.**>
+      @type record_transformer
+      @id kube_record_transformer
+      remove_keys kubernetes_namespace_container_name
+    </filter>
+
+    <filter kube.kube-system.**>
+      @type parser
+      @id kube_parser
+      format kubernetes
+      reserve_data true
+      key_name log
+    </filter>
+
+    <filter kube.**>
+      @type parser
+      key_name log
+      reserve_data true
+      remove_key_name_field false
+      emit_invalid_record_to_error false
+      <parse>
+        @type multi_format
+        <pattern>
+          format json
+          time_format %Y-%m-%dT%H:%M:%S.%N%Z
+        </pattern>
+        <pattern>
+          format json
+          time_format %Y-%m-%dT%H:%M:%S%z
+        </pattern>
+      </parse>
+    </filter>
+
+  output.conf: |
+    <filter **>
+      @type record_transformer
+      @id cluster_name
+      <record>
+        cluster_name "#{ENV['CLUSTER_NAME']}"
+      </record>
+    </filter>
+
+    # Force the timestamp field into ISO 8601 format
+    <filter **>
+      @type record_transformer
+      @id time_format
+      enable_ruby true
+      <record>
+        @timestamp ${time.iso8601(3)}
+      </record>
+    </filter>
+
+  es-output.conf: |
+    # Matches anything that Verrazzano installs
+    <match kubernetes.**_kube-** kubernetes.**_verrazzano-** kubernetes.**cattle-** kubernetes.**rancher-** kubernetes.**fleet-** kubernetes.**ingress-nginx** kubernetes.**istio-system** kubernetes.**keycloak** kubernetes.**mysql-operator** kubernetes.**cert-manager**  kubernetes.**_monitoring_** kubernetes.**_metallb-** kubernetes.**_local-path-storage_** kubernetes.**_local_** systemd.** kubernetes.**argocd** >
+      @type opensearch_data_stream
+      @id out_systemd
+      @log_level info
+      log_es_400_reason true
+      suppress_type_name true
+
+      data_stream_name verrazzano-system
+      data_stream_template_name verrazzano-data-stream
+      template_file /fluentd/etc/opensearch-template-verrazzano.json
+
+      time_precision 9
+
+      # Prevent reloading connections to Elasticsearch
+      reload_connections false
+      reconnect_on_error true
+      reload_on_failure true
+      slow_flush_log_threshold 120s
+
+      hosts "#{ENV['ELASTICSEARCH_URL']}"
+      ca_file "#{ENV['CA_FILE']}"
+      # ssl_version TLSv1_2
+      user "#{ENV['ELASTICSEARCH_USER']}"
+      password "#{ENV['ELASTICSEARCH_PASSWORD']}"
+
+      bulk_message_request_threshold 16M
+      request_timeout 2147483648
+      <buffer>
+        @type file
+        path /fluentd/log/system-buffer
+        flush_thread_count 8
+        flush_interval 5s
+        retry_forever
+        retry_max_interval 10
+        # Cap buffer memory usage to 16MiB/chunk * 10 chunks = 160 MiB
+        chunk_limit_size 16M
+        queue_limit_length 10
+        chunk_full_threshold 0.9
+        overflow_action drop_oldest_chunk
+      </buffer>
+    </match>
+    <match **>
+      @type opensearch_data_stream
+      @id out_all
+      @log_level info
+      log_es_400_reason true
+      suppress_type_name true
+
+      data_stream_name verrazzano-application-${$.kubernetes.namespace_name}
+      data_stream_template_name verrazzano-data-stream
+      template_file /fluentd/etc/opensearch-template-verrazzano.json
+
+      time_precision 9
+      # Prevent reloading connections to Elasticsearch
+      reload_connections false
+      reconnect_on_error true
+      reload_on_failure true
+      slow_flush_log_threshold 120s
+
+      hosts "#{ENV['ELASTICSEARCH_URL']}"
+      ca_file "#{ENV['CA_FILE']}"
+      # ssl_version TLSv1_2
+      user "#{ENV['ELASTICSEARCH_USER']}"
+      password "#{ENV['ELASTICSEARCH_PASSWORD']}"
+
+      bulk_message_request_threshold 16M
+      request_timeout 2147483648
+      <buffer tag, $.kubernetes.namespace_name>
+        @type file
+        path /fluentd/log/output-buffer
+        flush_thread_count 8
+        flush_interval 5s
+        retry_forever
+        retry_max_interval 10
+        # Cap buffer memory usage to 16MiB/chunk * 10 chunks = 160 MiB
+        chunk_limit_size 16M
+        queue_limit_length 10
+        chunk_full_threshold 0.9
+        overflow_action drop_oldest_chunk
+      </buffer>
+    </match>
+
+{{- if .Values.fluentd.oci }}
+  oci-logging-system.conf: |
+    # Match all "system" namespaces so system log records are sent to a separate OCI Log object
+    <match kubernetes.**_kube-** kubernetes.**_verrazzano-** kubernetes.**cattle-** kubernetes.**rancher-** kubernetes.**fleet-** kubernetes.**ingress-nginx** kubernetes.**istio-system** kubernetes.**keycloak** kubernetes.**mysql-operator** kubernetes.**cert-manager**  kubernetes.**_monitoring_** kubernetes.**_metallb-** kubernetes.**_local-path-storage_** kubernetes.**_local_** systemd.** kubernetes.**argocd**>
+      @type oci_logging
+      log_object_id {{ .Values.fluentd.oci.systemLogId }}
+      <buffer>
+        @type file
+        path /fluentd/log/oci-logging-system
+        disable_chunk_backup  true
+        chunk_limit_size  5MB
+        flush_interval  180s
+        total_limit_size  1GB
+        overflow_action  throw_exception
+        retry_type  exponential_backoff
+      </buffer>
+    </match>
+
+  oci-logging-default-app.conf: |
+    <match **>
+      @type oci_logging
+      log_object_id {{ .Values.fluentd.oci.defaultAppLogId }}
+      <buffer>
+        @type file
+        path /fluentd/log/oci-logging-default-app
+        disable_chunk_backup  true
+        chunk_limit_size  5MB
+        flush_interval  180s
+        total_limit_size  1GB
+        overflow_action  throw_exception
+        retry_type  exponential_backoff
+      </buffer>
+    </match>
+{{- end }}
+
+  opensearch-template-verrazzano.json: |
+    {
+      "index_patterns":[
+        "verrazzano-system",
+        "verrazzano-application*"
+      ],
+      "version":60001,
+      "priority": 101,
+      "data_stream": {},
+      "template": {
+        "settings":{
+          "index.refresh_interval":"5s",
+          "index.mapping.total_fields.limit":"2000",
+          "number_of_shards":1,
+          "index.number_of_replicas":0,
+          "index.auto_expand_replicas":"0-1"
+        },
+        "mappings":{
+          "dynamic_templates":[
+            {
+              "message_field":{
+                "path_match":"message",
+                "match_mapping_type":"string",
+                "mapping":{
+                  "type":"text",
+                  "norms":false
+                }
+              }
+            },
+            {
+              "object_fields": {
+                "match": "*",
+                "match_mapping_type": "object",
+                "mapping": {
+                  "type": "object"
+                }
+              }
+            },
+            {
+              "all_non_object_fields":{
+                "match":"*",
+                "mapping":{
+                  "type":"text",
+                  "norms":false,
+                  "fields":{
+                    "keyword":{
+                      "type":"keyword",
+                      "ignore_above":256
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "properties" : {
+            "@timestamp": { "type": "date", "format": "strict_date_time||strict_date_optional_time||epoch_millis"},
+            "kubernetes.pod_ip": {
+              "type": "text",
+              "norms": false,
+              "fields":{
+                "keyword":{
+                  "type":"keyword",
+                  "ignore_above":256
+                },
+                "ip":{
+                  "type": "ip",
+                  "ignore_malformed": true
+                }
+              }
+            },
+            "http_request.remoteIp": {
+              "type": "text",
+              "norms": false,
+              "fields":{
+                "keyword":{
+                  "type":"keyword",
+                  "ignore_above":256
+                },
+                "ip":{
+                  "type": "ip",
+                  "ignore_malformed": true
+                }
+              }
+            },
+            "http_request.responseSize": {
+              "type": "text",
+              "norms": false,
+              "fields":{
+                "keyword":{
+                  "type":"keyword",
+                  "ignore_above":256
+                },
+                "integer":{
+                  "type": "integer"
+                }
+              }
+            },
+            "http_request.status": {
+              "type": "text",
+              "norms": false,
+              "fields":{
+                "keyword":{
+                  "type":"keyword",
+                  "ignore_above":256
+                },
+                "integer":{
+                  "type": "integer"
+                }
+              }
+            },
+            "http_request.requestSize": {
+              "type": "text",
+              "norms": false,
+              "fields":{
+                "keyword":{
+                  "type":"keyword",
+                  "ignore_above":256
+                },
+                "integer":{
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        }
+      }
+    }

--- a/charts/fluentd-1.14.5/templates/fluentd-es-config-configmap.yaml
+++ b/charts/fluentd-1.14.5/templates/fluentd-es-config-configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.logging.name }}-es-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.logging.name }}
+data:
+  es-url: {{ .Values.logging.osURL }}
+  es-secret: {{ .Values.logging.credentialsSecret }}

--- a/charts/fluentd-1.14.5/templates/fluentd-init-configmap.yaml
+++ b/charts/fluentd-1.14.5/templates/fluentd-init-configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.logging.name }}-init
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.logging.name }}
+data:
+  init.sh: |
+    #!/bin/bash
+    cat /etc/ssl/certs/ca-bundle.crt > /fluentd/cacerts/all-ca-certs.pem
+    if [ -f "/fluentd/secret/ca-bundle" ]; then
+      cat /fluentd/secret/ca-bundle >> /fluentd/cacerts/all-ca-certs.pem
+    fi
+    if [ -f "/fluentd/secret/es-ca-bundle" ]; then
+      cat /fluentd/secret/es-ca-bundle >> /fluentd/cacerts/all-ca-certs.pem
+    fi

--- a/charts/fluentd-1.14.5/templates/service.yaml
+++ b/charts/fluentd-1.14.5/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: fluentd
+  labels:
+    app: fluentd
+spec:
+  ports:
+    - name: http-metrics
+      port: 24231
+      protocol: TCP
+      targetPort: 24231
+  selector:
+    app: fluentd

--- a/charts/fluentd-1.14.5/templates/serviceaccount.yaml
+++ b/charts/fluentd-1.14.5/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.logging.name }}
+  namespace: {{ .Release.Namespace }}
+  {{- if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+  {{- range .Values.global.imagePullSecrets }}
+  - name: {{ . }}
+  {{- end }}
+  {{- end }}

--- a/charts/fluentd-1.14.5/values.yaml
+++ b/charts/fluentd-1.14.5/values.yaml
@@ -1,0 +1,37 @@
+name: verrazzano-fluentd
+
+global:
+  imagePullSecrets: []
+
+image:
+  pullPolicy: IfNotPresent
+  terminationGracePeriodSeconds: 60
+
+logging:
+  credentialsSecret: 'my-secret'
+  usernameKey: username
+  passwordKey: password
+  clusterName: local
+  osURL: 'https://my-opensearch:9200'
+  name: fluentd
+  fluentdImage: container-registry.oracle.com/verrazzano/fluentd-kubernetes-daemonset:v1.14.5-20230922100900-8777b84
+  # NOTE: The fluentd-kubernetes-daemonset image now comes from the bill of materials file (verrazzano-bom.json).
+
+fluentd:
+  enabled: true
+
+monitoring:
+  enabled: true
+  useIstioCerts: true
+
+# In the environment where SELinux is enforcing, you can consider to override the default SELinux security context for the Fluentd so that it can have the required read/write privileges.
+# By customizing these options, you can ensure that Fluentd operates within the appropriate SELinux security context.
+seLinuxOptions:
+  # -- String to override the SELinux type for the Fluentd process. This determines the access permissions and restrictions for the Fluentd.
+  type: "" # spc_t
+  # -- String to override the  SELinux level for the Fluentd process. It represents the sensitivity level of the Fluentd in relation to other SELinux-labeled objects.
+  level: "" # s0
+  # -- String to override the SELinux role for the Fluentd process. It defines the role or set of permissions that the process running the Fluentd can have.
+  role: "" # system_r
+  # -- String to override the SELinux user for the Fluentd process. It specifies the SELinux user identity that the process should run as.
+  user: "" # system_u

--- a/charts/fluentd-1.14.5/values.yaml
+++ b/charts/fluentd-1.14.5/values.yaml
@@ -14,8 +14,7 @@ logging:
   clusterName: local
   osURL: 'https://my-opensearch:9200'
   name: fluentd
-  fluentdImage: container-registry.oracle.com/verrazzano/fluentd-kubernetes-daemonset:v1.14.5-20230922100900-8777b84
-  # NOTE: The fluentd-kubernetes-daemonset image now comes from the bill of materials file (verrazzano-bom.json).
+  fluentdImage: verrazzano/fluentd-kubernetes-daemonset:v1.14.5-20230922100900-8777b84
 
 fluentd:
   enabled: true


### PR DESCRIPTION
Add the Verrazzano chart for Fluentd 1.14.5 to the app-catalog and mark it as deprecated.

Tested with the following steps:
```
helm get values -n verrazzano-system fluentd > overrides.yaml
sed -i '1d' overrides.yaml
sed -i '/fluentdImage:/d' overrides.yaml
ocne application update --release fluentd --namespace verrazzano-system --version 1.14.5 --reset-values --values overrides.yaml --catalog embedded
```