### PR TITLE
Allow proxy configuration for all Cluster API providers

### DIFF
--- a/charts/bootstrap-capi-1.7.1/templates/deployment.yaml
+++ b/charts/bootstrap-capi-1.7.1/templates/deployment.yaml
@@ -26,6 +26,18 @@ spec:
         command:
         - /manager
         env:
+{{ if .Values.proxy.httpsProxy }}
+        - name: https_proxy
+          value: {{ quote .Values.proxy.httpsProxy }}
+{{ end }}
+{{ if .Values.proxy.httpProxy }}
+        - name: http_proxy
+          value: {{ quote .Values.proxy.httpProxy }}
+{{ end }}
+{{ if .Values.proxy.noProxy }}
+        - name: no_proxy
+          value: {{ quote .Values.proxy.noProxy }}
+{{ end }}
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:

--- a/charts/bootstrap-capi-1.7.1/values.yaml
+++ b/charts/bootstrap-capi-1.7.1/values.yaml
@@ -28,3 +28,7 @@ webhookService:
   - port: 443
     targetPort: webhook-server
   type: ClusterIP
+proxy:
+  httpsProxy:
+  httpProxy:
+  noProxy:

--- a/charts/control-plane-capi-1.7.1/templates/deployment.yaml
+++ b/charts/control-plane-capi-1.7.1/templates/deployment.yaml
@@ -26,6 +26,19 @@ spec:
         command:
         - /manager
         env:
+{{ if .Values.proxy.httpsProxy }}
+        - name: https_proxy
+          value: {{ quote .Values.proxy.httpsProxy }}
+{{ end }}
+{{ if .Values.proxy.httpProxy }}
+        - name: http_proxy
+          value: {{ quote .Values.proxy.httpProxy }}
+{{ end }}
+{{ if .Values.proxy.noProxy }}
+        - name: no_proxy
+          value: {{ quote .Values.proxy.noProxy }}
+{{ end }}
+        
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:

--- a/charts/control-plane-capi-1.7.1/values.yaml
+++ b/charts/control-plane-capi-1.7.1/values.yaml
@@ -27,3 +27,7 @@ webhookService:
   - port: 443
     targetPort: webhook-server
   type: ClusterIP
+proxy:
+  httpsProxy:
+  httpProxy:
+  noProxy:

--- a/charts/core-capi-1.7.1/templates/deployment.yaml
+++ b/charts/core-capi-1.7.1/templates/deployment.yaml
@@ -26,6 +26,18 @@ spec:
         command:
         - /manager
         env:
+{{ if .Values.proxy.httpsProxy }}
+        - name: https_proxy
+          value: {{ quote .Values.proxy.httpsProxy }}
+{{ end }}
+{{ if .Values.proxy.httpProxy }}
+        - name: http_proxy
+          value: {{ quote .Values.proxy.httpProxy }}
+{{ end }}
+{{ if .Values.proxy.noProxy }}
+        - name: no_proxy
+          value: {{ quote .Values.proxy.noProxy }}
+{{ end }}
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:

--- a/charts/core-capi-1.7.1/values.yaml
+++ b/charts/core-capi-1.7.1/values.yaml
@@ -27,3 +27,7 @@ webhookService:
   - port: 443
     targetPort: webhook-server
   type: ClusterIP
+proxy:
+  httpsProxy:
+  httpProxy:
+  noProxy:

--- a/charts/oci-capi-0.15.0/templates/auth-config.yaml
+++ b/charts/oci-capi-0.15.0/templates/auth-config.yaml
@@ -12,8 +12,7 @@ data:
     | b64enc | quote }}
   key: {{ required "authConfig.key is required" .Values.authConfig.key | b64enc |
     quote }}
-  passphrase: {{ required "authConfig.passphrase is required" .Values.authConfig.passphrase
-    | b64enc | quote }}
+  passphrase: {{ .Values.authConfig.passphrase | b64enc | quote }}
   region: {{ required "authConfig.region is required" .Values.authConfig.region |
     b64enc | quote }}
   tenancy: {{ required "authConfig.tenancy is required" .Values.authConfig.tenancy

--- a/charts/oci-capi-0.15.0/templates/deployment.yaml
+++ b/charts/oci-capi-0.15.0/templates/deployment.yaml
@@ -40,6 +40,18 @@ spec:
         command:
         - /manager
         env:
+{{ if .Values.proxy.httpsProxy }}
+        - name: https_proxy
+          value: {{ quote .Values.proxy.httpsProxy }}
+{{ end }}
+{{ if .Values.proxy.httpProxy }}
+        - name: http_proxy
+          value: {{ quote .Values.proxy.httpProxy }}
+{{ end }}
+{{ if .Values.proxy.noProxy }}
+        - name: no_proxy
+          value: {{ quote .Values.proxy.noProxy }}
+{{ end }}
         - name: AUTH_CONFIG_DIR
           value: {{ quote .Values.controllerManager.manager.env.authConfigDir }}
         - name: KUBERNETES_CLUSTER_DOMAIN

--- a/charts/oci-capi-0.15.0/values.yaml
+++ b/charts/oci-capi-0.15.0/values.yaml
@@ -58,3 +58,7 @@ webhookService:
     targetPort: webhook-server
   type: ClusterIP
 fullnameOverride: capoci
+proxy:
+  httpsProxy:
+  httpProxy:
+  noProxy:


### PR DESCRIPTION
Adds proxy configuration variables for all CAPI charts.  This allows for running the controllers in clusters that are behind a proxy but need to access clusters reachable on the internet.