### PR TITLE
It is possible to forget to add an icon to a chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ $(REPO_DIR):
 
 .SECONDEXPANSION:
 $(REPO_DIR)/%.tgz: $$(shell find $$(CHART_DIR)/$$* -type f) | $(REPO_DIR)
+	$$(yq '.icon != null' $(CHART_DIR)/$(basename $(notdir $@))/Chart.yaml)
+	stat ./olm/$(shell yq '.icon' $(CHART_DIR)/$(basename $(notdir $@))/Chart.yaml)
 	helm package $(CHART_DIR)/$(basename $(notdir $@)) -d $(REPO_DIR) --dependency-update
 
 $(REPO_DIR)/index.yaml: $(CHART_TARBALLS) $(REPO_DIR)

--- a/buildrpm/ocne-catalog.spec
+++ b/buildrpm/ocne-catalog.spec
@@ -13,6 +13,7 @@ Source0:	%{name}-%{version}.tar.bz2
 BuildRequires:	helm
 BuildRequires:	make
 BuildRequires:	findutils
+BuildRequires:  yq
 
 %description
 An on-disk Helm chart repository


### PR DESCRIPTION
Add two checks to the Makefile target for a chart tarball
- Does the Chart.yaml contain an "icon:"
- Does that field point to a file that exists in the right spot in this repo