### PR TITLE
Support DaemonSet for istio-ingress charts for 1.19.9 and 1.20.5

### DIFF
--- a/charts/istio-ingress-1.19.9/templates/autoscale.yaml
+++ b/charts/istio-ingress-1.19.9/templates/autoscale.yaml
@@ -17,7 +17,7 @@ spec:
   minReplicas: {{ $gateway.autoscaleMin }}
   scaleTargetRef:
     apiVersion: apps/v1
-    kind: Deployment
+    kind: {{ .Values.kind | default "Deployment" }}
     name: {{ $gateway.name }}
   metrics:
   - type: Resource
@@ -46,7 +46,7 @@ spec:
   minReplicas: {{ $gateway.autoscaleMin }}
   scaleTargetRef:
     apiVersion: apps/v1
-    kind: Deployment
+    kind: {{ .Values.kind | default "Deployment" }}
     name: {{ $gateway.name }}
   metrics:
   - type: Resource

--- a/charts/istio-ingress-1.19.9/templates/autoscale.yaml
+++ b/charts/istio-ingress-1.19.9/templates/autoscale.yaml
@@ -1,5 +1,5 @@
 {{ $gateway := index .Values "gateways" "istio-ingressgateway" }}
-{{- if and $gateway.autoscaleEnabled $gateway.autoscaleMin $gateway.autoscaleMax }}
+{{- if and ($gateway.autoscaleEnabled) ($gateway.autoscaleMin) ($gateway.autoscaleMax) (eq .Values.kind "Deployment") }}
 {{- if not .Values.global.autoscalingv2API }}
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler

--- a/charts/istio-ingress-1.19.9/templates/deployment.yaml
+++ b/charts/istio-ingress-1.19.9/templates/deployment.yaml
@@ -1,7 +1,7 @@
 {{- $gateway := index .Values "gateways" "istio-ingressgateway" }}
 {{- if eq $gateway.injectionTemplate "" }}
 apiVersion: apps/v1
-kind: Deployment
+kind: {{ .Values.kind | default "Deployment" }}
 metadata:
   name: {{ $gateway.name }}
   namespace: {{ .Release.Namespace }}

--- a/charts/istio-ingress-1.19.9/templates/deployment.yaml
+++ b/charts/istio-ingress-1.19.9/templates/deployment.yaml
@@ -20,10 +20,12 @@ spec:
   selector:
     matchLabels:
 {{ $gateway.labels | toYaml | indent 6 }}
+{{- if eq .Values.kind "Deployment" }}
   strategy:
     rollingUpdate:
       maxSurge: {{ $gateway.rollingMaxSurge }}
       maxUnavailable: {{ $gateway.rollingMaxUnavailable }}
+{{- end }}
   template:
     metadata:
       labels:

--- a/charts/istio-ingress-1.19.9/values.yaml
+++ b/charts/istio-ingress-1.19.9/values.yaml
@@ -317,3 +317,5 @@ meshConfig:
     #        sni:               # example: tracer.somedomain
     #        subjectAltNames: []
     # - tracer.somedomain
+
+kind: Deployment

--- a/charts/istio-ingress-1.20.5/templates/autoscale.yaml
+++ b/charts/istio-ingress-1.20.5/templates/autoscale.yaml
@@ -17,7 +17,7 @@ spec:
   minReplicas: {{ $gateway.autoscaleMin }}
   scaleTargetRef:
     apiVersion: apps/v1
-    kind: Deployment
+    kind: {{ .Values.kind | default "Deployment" }}
     name: {{ $gateway.name }}
   metrics:
   - type: Resource
@@ -46,7 +46,7 @@ spec:
   minReplicas: {{ $gateway.autoscaleMin }}
   scaleTargetRef:
     apiVersion: apps/v1
-    kind: Deployment
+    kind: {{ .Values.kind | default "Deployment" }}
     name: {{ $gateway.name }}
   metrics:
   - type: Resource

--- a/charts/istio-ingress-1.20.5/templates/autoscale.yaml
+++ b/charts/istio-ingress-1.20.5/templates/autoscale.yaml
@@ -1,5 +1,5 @@
 {{ $gateway := index .Values "gateways" "istio-ingressgateway" }}
-{{- if and $gateway.autoscaleEnabled $gateway.autoscaleMin $gateway.autoscaleMax }}
+{{- if and ($gateway.autoscaleEnabled) ($gateway.autoscaleMin) ($gateway.autoscaleMax) (eq .Values.kind "Deployment") }}
 {{- if not .Values.global.autoscalingv2API }}
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler

--- a/charts/istio-ingress-1.20.5/templates/deployment.yaml
+++ b/charts/istio-ingress-1.20.5/templates/deployment.yaml
@@ -1,7 +1,7 @@
 {{- $gateway := index .Values "gateways" "istio-ingressgateway" }}
 {{- if eq $gateway.injectionTemplate "" }}
 apiVersion: apps/v1
-kind: Deployment
+kind: {{ .Values.kind | default "Deployment" }}
 metadata:
   name: {{ $gateway.name }}
   namespace: {{ .Release.Namespace }}

--- a/charts/istio-ingress-1.20.5/templates/deployment.yaml
+++ b/charts/istio-ingress-1.20.5/templates/deployment.yaml
@@ -20,10 +20,12 @@ spec:
   selector:
     matchLabels:
 {{ $gateway.labels | toYaml | indent 6 }}
+{{- if eq .Values.kind "Deployment" }}
   strategy:
     rollingUpdate:
       maxSurge: {{ $gateway.rollingMaxSurge }}
       maxUnavailable: {{ $gateway.rollingMaxUnavailable }}
+{{- end }}
   template:
     metadata:
       labels:

--- a/charts/istio-ingress-1.20.5/values.yaml
+++ b/charts/istio-ingress-1.20.5/values.yaml
@@ -321,3 +321,5 @@ meshConfig:
     #        sni:               # example: tracer.somedomain
     #        subjectAltNames: []
     # - tracer.somedomain
+
+kind: Deployment


### PR DESCRIPTION
Fixes #101

Instructions shown for istio-ingress 1.19.9 (similar applies for 1.20.5 - just change the version)

Prerequisites (for either deploying istio-ingress as Deployment or DaemonSet):
Please execute below instructions 
```shell
istio_version=1.19.9
ocne application install --name istio-base --version $istio_version --namespace istio-system
ocne application install --name istiod --version $istio_version --namespace istio-system
```
When deploying istio-ingress as DaemonSet
```shell
# Create an helm overrides values yaml file for specifying istio-ingress as DaemonSet
# Note: Using embedded catalog for testing purposes
echo "kind: DaemonSet" > ~/daemonset.yaml
ocne application install --name istio-ingress --version $istio_version --namespace istio-system --values ~/daemonset.yaml -c embedded
``` 
```shell
kubectl get all -A
```
Output below
<details><summary>Details</summary>
<p>

```shell
NAMESPACE      NAME                                               READY   STATUS    RESTARTS   AGE
istio-system   pod/istio-ingressgateway-pqnmt                     1/1     Running   0          10s
istio-system   pod/istiod-6d4d8db6b6-h4zft                        1/1     Running   0          2m33s
kube-flannel   pod/kube-flannel-ds-kz575                          1/1     Running   0          3m12s
kube-system    pod/coredns-685ccdb94-6z275                        1/1     Running   0          3m13s
kube-system    pod/coredns-685ccdb94-v7v9f                        1/1     Running   0          3m13s
kube-system    pod/etcd-ocne-control-plane-1                      1/1     Running   0          3m16s
kube-system    pod/kube-apiserver-ocne-control-plane-1            1/1     Running   0          3m16s
kube-system    pod/kube-controller-manager-ocne-control-plane-1   1/1     Running   0          3m16s
kube-system    pod/kube-proxy-dxbbt                               1/1     Running   0          3m12s
kube-system    pod/kube-scheduler-ocne-control-plane-1            1/1     Running   0          3m16s
ocne-system    pod/ocne-catalog-578c959566-rpcnh                  1/1     Running   0          3m11s

NAMESPACE      NAME                           TYPE           CLUSTER-IP       EXTERNAL-IP   PORT(S)                                      AGE
default        service/kubernetes             ClusterIP      10.96.0.1        <none>        443/TCP                                      3m41s
istio-system   service/istio-ingressgateway   LoadBalancer   10.103.194.133   <pending>     15021:30173/TCP,80:31090/TCP,443:32313/TCP   10s
istio-system   service/istiod                 ClusterIP      10.108.125.125   <none>        15010/TCP,15012/TCP,443/TCP,15014/TCP        2m33s
kube-system    service/kube-dns               ClusterIP      10.96.0.10       <none>        53/UDP,53/TCP                                3m13s
ocne-system    service/ocne-catalog           NodePort       10.104.59.197    <none>        80:31316/TCP                                 3m11s

NAMESPACE      NAME                                  DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR            AGE
istio-system   daemonset.apps/istio-ingressgateway   1         1         1       1            1           <none>                   10s
kube-flannel   daemonset.apps/kube-flannel-ds        1         1         1       1            1           <none>                   3m12s
kube-system    daemonset.apps/kube-proxy             1         1         1       1            1           kubernetes.io/os=linux   3m12s

NAMESPACE      NAME                           READY   UP-TO-DATE   AVAILABLE   AGE
istio-system   deployment.apps/istiod         1/1     1            1           2m33s
kube-system    deployment.apps/coredns        2/2     2            2           3m13s
ocne-system    deployment.apps/ocne-catalog   1/1     1            1           3m11s

NAMESPACE      NAME                                      DESIRED   CURRENT   READY   AGE
istio-system   replicaset.apps/istiod-6d4d8db6b6         1         1         1       2m33s
kube-system    replicaset.apps/coredns-685ccdb94         2         2         2       3m13s
ocne-system    replicaset.apps/ocne-catalog-578c959566   1         1         1       3m11s

NAMESPACE      NAME                                         REFERENCE           TARGETS              MINPODS   MAXPODS   REPLICAS   AGE
istio-system   horizontalpodautoscaler.autoscaling/istiod   Deployment/istiod   cpu: <unknown>/80%   1         5         1          2m33s
```
</p>
</details>

When deploying istio-ingress as Deployment
```shell
# Note: Using embedded catalog for testing purposes
ocne application install --name istio-ingress --version $istio_version --namespace istio-system -c embedded
``` 
```shell
kubectl get all -A
```

Output below
<details><summary>Details</summary>
<p>

```shell
NAMESPACE      NAME                                               READY   STATUS    RESTARTS   AGE
istio-system   pod/istio-ingressgateway-57bbcf4ff-j5wbs           1/1     Running   0          5s
istio-system   pod/istiod-6d4d8db6b6-h4zft                        1/1     Running   0          33m
kube-flannel   pod/kube-flannel-ds-kz575                          1/1     Running   0          34m
kube-system    pod/coredns-685ccdb94-6z275                        1/1     Running   0          34m
kube-system    pod/coredns-685ccdb94-v7v9f                        1/1     Running   0          34m
kube-system    pod/etcd-ocne-control-plane-1                      1/1     Running   0          34m
kube-system    pod/kube-apiserver-ocne-control-plane-1            1/1     Running   0          34m
kube-system    pod/kube-controller-manager-ocne-control-plane-1   1/1     Running   0          34m
kube-system    pod/kube-proxy-dxbbt                               1/1     Running   0          34m
kube-system    pod/kube-scheduler-ocne-control-plane-1            1/1     Running   0          34m
ocne-system    pod/ocne-catalog-578c959566-rpcnh                  1/1     Running   0          34m

NAMESPACE      NAME                           TYPE           CLUSTER-IP       EXTERNAL-IP   PORT(S)                                      AGE
default        service/kubernetes             ClusterIP      10.96.0.1        <none>        443/TCP                                      34m
istio-system   service/istio-ingressgateway   LoadBalancer   10.103.22.87     <pending>     15021:31395/TCP,80:31124/TCP,443:30628/TCP   5s
istio-system   service/istiod                 ClusterIP      10.108.125.125   <none>        15010/TCP,15012/TCP,443/TCP,15014/TCP        33m
kube-system    service/kube-dns               ClusterIP      10.96.0.10       <none>        53/UDP,53/TCP                                34m
ocne-system    service/ocne-catalog           NodePort       10.104.59.197    <none>        80:31316/TCP                                 34m

NAMESPACE      NAME                             DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR            AGE
kube-flannel   daemonset.apps/kube-flannel-ds   1         1         1       1            1           <none>                   34m
kube-system    daemonset.apps/kube-proxy        1         1         1       1            1           kubernetes.io/os=linux   34m

NAMESPACE      NAME                                   READY   UP-TO-DATE   AVAILABLE   AGE
istio-system   deployment.apps/istio-ingressgateway   1/1     1            1           5s
istio-system   deployment.apps/istiod                 1/1     1            1           33m
kube-system    deployment.apps/coredns                2/2     2            2           34m
ocne-system    deployment.apps/ocne-catalog           1/1     1            1           34m

NAMESPACE      NAME                                             DESIRED   CURRENT   READY   AGE
istio-system   replicaset.apps/istio-ingressgateway-57bbcf4ff   1         1         1       5s
istio-system   replicaset.apps/istiod-6d4d8db6b6                1         1         1       33m
kube-system    replicaset.apps/coredns-685ccdb94                2         2         2       34m
ocne-system    replicaset.apps/ocne-catalog-578c959566          1         1         1       34m

NAMESPACE      NAME                                                       REFERENCE                         TARGETS              MINPODS   MAXPODS   REPLICAS   AGE
istio-system   horizontalpodautoscaler.autoscaling/istio-ingressgateway   Deployment/istio-ingressgateway   cpu: <unknown>/80%   1         5         0          5s
istio-system   horizontalpodautoscaler.autoscaling/istiod                 Deployment/istiod                 cpu: <unknown>/80%   1         5         1          33m
```
</p>
</details> 
 