### PR TITLE
Tell CLI to skip mirroring kube-proxy, Flannel, and CoreDNS

### DIFF
--- a/charts/coredns-2.0.0/Chart.yaml
+++ b/charts/coredns-2.0.0/Chart.yaml
@@ -17,3 +17,5 @@ maintainers:
   - name: hagaibarel
   - name: shubham-cmyk
 type: application
+annotations:
+  ocne.oracle.com/mirror: false

--- a/charts/flannel-2.0.0/Chart.yaml
+++ b/charts/flannel-2.0.0/Chart.yaml
@@ -8,3 +8,5 @@ sources:
 - https://github.com/flannel-io/flannel
 version: 2.0.0
 icon: icons/flannel-icon.svg
+annotations:
+  ocne.oracle.com/mirror: false

--- a/charts/flannel-2.0.0/values.yaml
+++ b/charts/flannel-2.0.0/values.yaml
@@ -9,7 +9,7 @@ flannel:
   # kube-flannel image
   image:
     repository: container-registry.oracle.com/olcne/flannel
-    tag: v0.22.3-1
+    tag: current
   image_cni:
     repository:
     tag:

--- a/charts/kube-proxy-2.0.0/Chart.yaml
+++ b/charts/kube-proxy-2.0.0/Chart.yaml
@@ -23,3 +23,5 @@ version: 2.0.0
 # It is recommended to use it with quotes.
 appVersion: "2.0.0"
 icon: icons/kubernetes-logo.svg 
+annotations:
+  ocne.oracle.com/mirror: false


### PR DESCRIPTION
These applications use the "current" tag when they are installed to facilitate air-gapped upgrade.  Since they are baked in to OCK and don't indicate a specific version, they don't make sense to include in OCR or to mirror.  Tell them to be skipped during catalog mirroring.