### PR TITLE
143 change ovirt csi driver chart to get cacrt from configmap

### DIFF
--- a/charts/ovirt-csi-driver-4.20.0/templates/csi_driver.yaml
+++ b/charts/ovirt-csi-driver-4.20.0/templates/csi_driver.yaml
@@ -1,7 +1,7 @@
 apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
-  name: csi.ovirt.org
+  name: {{ .Values.driver.name }}
   labels:
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/part-of: csi-driver-ovirt

--- a/charts/ovirt-csi-driver-4.20.0/templates/csi_driver_controller.yaml
+++ b/charts/ovirt-csi-driver-4.20.0/templates/csi_driver_controller.yaml
@@ -138,7 +138,7 @@ spec:
           ovirt_password: $OVIRT_PASSWORD
           # set a valid path only if ca bundle has content
           ovirt_cafile: ${OVIRT_CA_BUNDLE:+$OVIRT_CAFILE}
-          ovirt_insecure: $OVIRT_INSECURE
+          ovirt_insecure: {{ .Values.ovirt.insecure }}
           EOF
           if [[ -n "$OVIRT_CA_BUNDLE" ]]; then echo "$OVIRT_CA_BUNDLE" > $OVIRT_CAFILE ; fi
         env:
@@ -146,29 +146,26 @@ spec:
           valueFrom:
             secretKeyRef:
               key: ovirt_url
-              name: {{ include "mychart.fullname" . }}
+              name: {{ .Values.ovirt.secretName }}
         - name: OVIRT_USERNAME
           valueFrom:
             secretKeyRef:
               key: ovirt_username
-              name: {{ include "mychart.fullname" . }}
+              name: {{ .Values.ovirt.secretName }}
         - name: OVIRT_PASSWORD
           valueFrom:
             secretKeyRef:
               key: ovirt_password
-              name: {{ include "mychart.fullname" . }}
+              name: {{ .Values.ovirt.secretName }}
+{{ if .Values.ovirt.caProvided }}
         - name: OVIRT_CAFILE
           value: {{ quote .Values.csiController.prepareOvirtConfig.env.ovirtCafile }}
-        - name: OVIRT_INSECURE
-          valueFrom:
-            secretKeyRef:
-              key: ovirt_insecure
-              name: {{ include "mychart.fullname" . }}
         - name: OVIRT_CA_BUNDLE
           valueFrom:
-            secretKeyRef:
-              key: ovirt_ca_bundle
-              name: {{ include "mychart.fullname" . }}
+            configMapKeyRef:
+              key: ca.crt
+              name:  {{ .Values.ovirt.caConfigMapName }}
+{{ end }}
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}
         image: {{ .Values.csiController.prepareOvirtConfig.image.repository }}:{{ .Values.csiController.prepareOvirtConfig.image.tag

--- a/charts/ovirt-csi-driver-4.20.0/templates/csi_driver_controller.yaml
+++ b/charts/ovirt-csi-driver-4.20.0/templates/csi_driver_controller.yaml
@@ -1,7 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: csi-ovirt-controller
+  name: {{ .Values.csiController.ovirtController.name }}
+  namespace: '{{ .Release.Namespace }}'
   labels:
     app.kubernetes.io/component: plugin
     app.kubernetes.io/part-of: ovirt-csi-driver
@@ -146,17 +147,17 @@ spec:
           valueFrom:
             secretKeyRef:
               key: ovirt_url
-              name: {{ .Values.ovirt.secretName }}
+              name:  {{ .Values.ovirt.secretName }}
         - name: OVIRT_USERNAME
           valueFrom:
             secretKeyRef:
               key: ovirt_username
-              name: {{ .Values.ovirt.secretName }}
+              name:  {{ .Values.ovirt.secretName }}
         - name: OVIRT_PASSWORD
           valueFrom:
             secretKeyRef:
               key: ovirt_password
-              name: {{ .Values.ovirt.secretName }}
+              name:  {{ .Values.ovirt.secretName }}
 {{ if .Values.ovirt.caProvided }}
         - name: OVIRT_CAFILE
           value: {{ quote .Values.csiController.prepareOvirtConfig.env.ovirtCafile }}

--- a/charts/ovirt-csi-driver-4.20.0/templates/csi_driver_node.yaml
+++ b/charts/ovirt-csi-driver-4.20.0/templates/csi_driver_node.yaml
@@ -1,7 +1,8 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: csi-ovirt-node
+  name: {{ .Values.csiNode.ovirtNode.name }}
+  namespace: '{{ .Release.Namespace }}'
   labels:
     app.kubernetes.io/component: plugin
     app.kubernetes.io/part-of: csi-driver-ovirt

--- a/charts/ovirt-csi-driver-4.20.0/templates/csi_driver_node.yaml
+++ b/charts/ovirt-csi-driver-4.20.0/templates/csi_driver_node.yaml
@@ -120,7 +120,7 @@ spec:
           ovirt_password: $OVIRT_PASSWORD
           # set a valid path only if ca bundle has content
           ovirt_cafile: ${OVIRT_CA_BUNDLE:+$OVIRT_CAFILE}
-          ovirt_insecure: $OVIRT_INSECURE
+          ovirt_insecure: {{ .Values.ovirt.insecure }}
           EOF
           if [[ -n "$OVIRT_CA_BUNDLE" ]]; then echo "$OVIRT_CA_BUNDLE" > $OVIRT_CAFILE ; fi
         env:
@@ -128,30 +128,27 @@ spec:
           valueFrom:
             secretKeyRef:
               key: ovirt_url
-              name: {{ include "mychart.fullname" . }}
+              name: {{ .Values.ovirt.secretName }}
         - name: OVIRT_USERNAME
           valueFrom:
             secretKeyRef:
               key: ovirt_username
-              name: {{ include "mychart.fullname" . }}
+              name: {{ .Values.ovirt.secretName }}
         - name: OVIRT_PASSWORD
           valueFrom:
             secretKeyRef:
               key: ovirt_password
-              name: {{ include "mychart.fullname" . }}
+              name: {{ .Values.ovirt.secretName }}
+{{ if .Values.ovirt.caProvided }}
         - name: OVIRT_CAFILE
           value: {{ quote .Values.csiNode.prepareOvirtConfig.env.ovirtCafile
             }}
-        - name: OVIRT_INSECURE
-          valueFrom:
-            secretKeyRef:
-              key: ovirt_insecure
-              name: {{ include "mychart.fullname" . }}
         - name: OVIRT_CA_BUNDLE
           valueFrom:
-            secretKeyRef:
-              key: ovirt_ca_bundle
-              name: {{ include "mychart.fullname" . }}
+            configMapKeyRef:
+              key: ca.crt
+              name: {{ .Values.ovirt.caConfigMapName }}
+{{ end }}
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}
         image: {{ .Values.csiNode.prepareOvirtConfig.image.repository }}:{{

--- a/charts/ovirt-csi-driver-4.20.0/values.yaml
+++ b/charts/ovirt-csi-driver-4.20.0/values.yaml
@@ -50,6 +50,7 @@ csiController:
         cpu: 80m
         memory: 64Mi
   ovirtController:
+    name: ovirt-csi-controller-plugin
     containerSecurityContext:
       privileged: true
     env:
@@ -102,6 +103,7 @@ csiNode:
         cpu: 80m
         memory: 64Mi
   ovirtNode:
+    name: ovirt-csi-node-plugin
     containerSecurityContext:
       privileged: true
     env:
@@ -132,9 +134,9 @@ csiNode:
 kubernetesClusterDomain: cluster.local
 ovirt:
   caProvided: true
-  insecure: true
+  insecure: false
   secretName: ovirt-csi-creds
-  caConfigMapName: ovirt-csi-ca
+  caConfigMapName: ovirt-csi-ca.crt
 ovirtCsiDriverControllerSa:
   serviceAccount:
     annotations: {}
@@ -145,3 +147,7 @@ pvc:
   1GOvirtCowDisk:
     storageClass: ovirt-csi-sc
     storageRequest: 1Gi
+
+driver:
+  name: csi.ovirt.org
+

--- a/charts/ovirt-csi-driver-4.20.0/values.yaml
+++ b/charts/ovirt-csi-driver-4.20.0/values.yaml
@@ -130,6 +130,11 @@ csiNode:
         cpu: 10m
         memory: 50Mi
 kubernetesClusterDomain: cluster.local
+ovirt:
+  caProvided: true
+  insecure: true
+  secretName: ovirt-csi-creds
+  caConfigMapName: ovirt-csi-ca
 ovirtCsiDriverControllerSa:
   serviceAccount:
     annotations: {}


### PR DESCRIPTION
Make the following changes:

* allow ca.crt configmap to be set to allow secure TLS to ovirt server
* make insecure default false
* optionally use ca in the truststore instead of in configmap
* allow multiple drivers to be installed (by changing driver name)

Tests:
I installed both secure and insecure and created a testpod with attached volume and ensured that data did not get lost on pod re-creation.

# install with ca.crt and tests secure connection
```
hh install ovirt-demo -n ovirt-csi-driver ovirt-csi-driver-4.20.0/ 

--driver pods--
ovirt-csi-driver   ovirt-csi-controller-plugin-94ccc59dd-wtpd8        5/5     Running   0               3s
ovirt-csi-driver   ovirt-csi-node-plugin-wtbx6                        3/3     Running   0               3s

-- configmap 
ovirt-csi-driver   ovirt-csi-ca.crt                                       1      16s

--secret
ovirt-csi-driver   ovirt-csi-creds                                     Opaque               4      5s

--driver
csi.ovirt.org   true             false            false             <unset>         false               Persistent   21m

-- bin.txt has data in /paul using ovirt-csi-driver and survived pod restart
kk get pod
NAME       READY   STATUS    RESTARTS   AGE
test-csi   1/1     Running   0          11s
~/olvm> kk exec -it test-csi bash
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
[root@test-csi /]# ls /paul
bin.txt  lost+found

```