### PR TITLE
Add olvm capi chart to the catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ installing the `ocne-catalog` chart.
 | Multus                                              | multus                      | 4.0.2                      |
 | OAuth2 Proxy                                        | oauth2-proxy                | 7.8.0                      |
 | OCI Cloud Controller Manager                        | oci-ccm                     | 1.30.0<br>1.28.0           |
+| OLVM CAPI Controller Manager                        | olvm-capi                   | 1.0.0                      |
 | OpenSearch                                          | opensearch                  | 2.15.0                     |
 | OpenSearch Dashboards                               | opensearch-dashboards       | 2.15.0                     |
 | Oracle Cloud Native Environment Application Catalog | ocne-catalog                | 2.0.0                      |

--- a/buildrpm/ocne-catalog-container-image.spec
+++ b/buildrpm/ocne-catalog-container-image.spec
@@ -7,7 +7,7 @@
 
 Name:		%{_name}-container-image
 Version:	2.0.0
-Release:	13%{?dist}
+Release:	14%{?dist}
 Summary:	An on-disk Helm chart repository
 
 Group:		Development/Tools
@@ -37,6 +37,9 @@ docker save -o %{_name}.tar %{docker_tag}
 %clean
 
 %changelog
+* Thu May 1 2025 Paul Mackin <paul.mackin@oracle.com> - 2.0.0-14
+- Add olvm-capi-1.0.0 to the catalog
+
 * Sat Apr 05 2025 Daniel Krasinski <daniel.krasinski@oracle.com> - 2.0.0-13
 - Use common base image
 

--- a/buildrpm/ocne-catalog.spec
+++ b/buildrpm/ocne-catalog.spec
@@ -3,7 +3,7 @@
 
 Name:		ocne-catalog
 Version:	2.0.0
-Release:	13%{?dist}
+Release:	14%{?dist}
 Summary:	An on-disk Helm chart repository
 
 Group:		Development/Tools
@@ -37,6 +37,9 @@ cp -ap olm/icons/* %{buildroot}/opt/icons
 /opt/icons
 
 %changelog
+* Thu May 1 2025 Paul Mackin <paul.mackin@oracle.com> - 2.0.0-14
+- Add olvm-capi-1.0.0 to the catalog
+
 * Sat Apr 05 2025 Daniel Krasinski <daniel.krasinski@oracle.com> - 2.0.0-13
 - Use common base image
 

--- a/charts/olvm-capi-1.0.0/.helmignore
+++ b/charts/olvm-capi-1.0.0/.helmignore
@@ -1,0 +1,26 @@
+# Copyright (c) 2024, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/olvm-capi-1.0.0/Chart.yaml
+++ b/charts/olvm-capi-1.0.0/Chart.yaml
@@ -1,0 +1,25 @@
+# Copyright (c) 2024, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+apiVersion: v2
+name: olvm-capi
+description: Helm chart for Cluster API Provider OLVM
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 1.0.0
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.0.0"
+icon: icons/oracle.png

--- a/charts/olvm-capi-1.0.0/crds/infrastructure.cluster.x-k8s.io_olvmclusters.yaml
+++ b/charts/olvm-capi-1.0.0/crds/infrastructure.cluster.x-k8s.io_olvmclusters.yaml
@@ -1,0 +1,242 @@
+# Copyright (c) 2024, 2025, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-olvm
+    cluster.x-k8s.io/v1beta1: v1
+  name: olvmclusters.infrastructure.cluster.x-k8s.io
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: OLVMCluster
+    listKind: OLVMClusterList
+    plural: olvmclusters
+    shortNames:
+    - olvmc
+    singular: olvmcluster
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: True if the OlvmCluster is ready
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: The OLVM Data Center that contains the OLVM Cluster
+      jsonPath: .status.olvmDatacenter.dataCenterName
+      name: DataCenter
+      type: string
+    - description: The age of the OlvmCluster
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: The URL of the OLVM API server
+      jsonPath: .spec.olvmOvirtAPIServer.serverURL
+      name: OLVMServerURL
+      priority: 2
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: OLVMCluster specifies am  OLVMCluster instance.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OLVMClusterSpec defines the specification for a OLVMCluster
+              resource.
+            properties:
+              controlPlaneEndpoint:
+                description: ControlPlaneEndpoint specifies the Kubernetes control
+                  plane endpoint.
+                properties:
+                  host:
+                    description: Host is the endpoint host name or IP address.
+                    type: string
+                  port:
+                    description: Port is the endpoint port.
+                    format: int32
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              olvmDatacenterName:
+                description: OlvmDatacenterName is the datacenter where the Kubernetes
+                  cluster will be created.
+                type: string
+              olvmOvirtAPIServer:
+                description: OlvmOvirtAPIServer contains the information needed to
+                  use the OLVM oVirt REST API server.
+                properties:
+                  caConfigMap:
+                    description: |-
+                      CAConfigMap is the namespaced name of the ConfigMap which has the CA.CRT for the OLVM endpoint.
+                      For example: https://example.com/ovirt-engine
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  credentialsSecret:
+                    description: CredentialsSecretName is the namespaced name of the
+                      Secret which has the credentials needed to access the OLVM endpoint.
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  insecureSkipTLSVerify:
+                    description: InsecureSkipTLSVerify skips OLVM TLS certificate
+                      verification.
+                    type: boolean
+                  serverURL:
+                    description: ServerURL is the OLVM oVirt REST API endpoint URL.
+                    type: string
+                required:
+                - credentialsSecret
+                - serverURL
+                type: object
+            required:
+            - controlPlaneEndpoint
+            - olvmDatacenterName
+            - olvmOvirtAPIServer
+            type: object
+          status:
+            description: OLVMClusterStatus defines the status OlvmCluster resource.
+            properties:
+              conditions:
+                description: Conditions are the list of conditions for the OlvmCluster.
+                items:
+                  description: ClusterCondition describes the current condition of
+                    the OlvmCluster.
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time the condition
+                        transitioned from one status to another.
+                      type: string
+                    message:
+                      description: Message is a human-readable message indicating
+                        details about the last transition.
+                      type: string
+                    reason:
+                      description: Reason for the condition.  This is a machine-readable
+                        one word value.
+                      type: string
+                    status:
+                      description: 'Status of the condition: one of `True`, `False`,
+                        or `Unknown`.'
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureDomains:
+                additionalProperties:
+                  description: FailureDomainSpec specifies a failuredomain
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: Attributes are arbitrary attributes for users to
+                        apply to a failure domain.
+                      type: object
+                    controlPlane:
+                      description: ControlPlane indicates if failure domain is appropriate
+                        for running control plane instances.
+                      type: boolean
+                  required:
+                  - controlPlane
+                  type: object
+                description: |-
+                  FailureDomains is the failure domains that machines should be placed in.
+                  The maputil key is the FailureDomain name
+                type: object
+              failureMessage:
+                description: |-
+                  FailureMessage indicates there is a fatal problem reconciling the provider’s infrastructure;
+                  meant to be a more descriptive value than failureReason
+                type: string
+              failureReason:
+                description: |-
+                  FailureReason indicates there is a fatal problem reconciling the provider’s infrastructure;
+                  meant to be suitable for programmatic interpretation
+                type: string
+              lastObservedGeneration:
+                description: |-
+                  LastObservedGeneration is the latest generation of the OlvmCluster
+                  that the controller_foundation has seen, but not necessarily reconciled.
+                format: int64
+                type: integer
+              lastSuccessfulGeneration:
+                description: LastSuccessfulGeneration is the last generation of the
+                  OlvmCluster that was successfully reconciled.
+                format: int64
+                type: integer
+              olvmDatacenter:
+                description: OlvmDatacenter describes the OLVM datacenter.
+                properties:
+                  dataCenterID:
+                    description: DataCenterID is the datacenter ID.
+                    type: string
+                  dataCenterName:
+                    description: DataCenterName is the datacenter name.
+                    type: string
+                  release:
+                    description: Release describes the OLVM Release.
+                    properties:
+                      name:
+                        description: Name is the name of the OLVM product.
+                        type: string
+                      version:
+                        description: Version is the OLVM version.
+                        type: string
+                    type: object
+                type: object
+              ready:
+                description: Ready indicates the provider-specific infrastructure
+                  has been provisioned and is ready
+                type: boolean
+            required:
+            - ready
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/olvm-capi-1.0.0/crds/infrastructure.cluster.x-k8s.io_olvmclustertemplates.yaml
+++ b/charts/olvm-capi-1.0.0/crds/infrastructure.cluster.x-k8s.io_olvmclustertemplates.yaml
@@ -1,0 +1,137 @@
+# Copyright (c) 2024, 2025, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-olvm
+    cluster.x-k8s.io/v1beta1: v1
+  name: olvmclustertemplates.infrastructure.cluster.x-k8s.io
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: OLVMClusterTemplate
+    listKind: OLVMClusterTemplateList
+    plural: olvmclustertemplates
+    shortNames:
+    - olvmct
+    singular: olvmclustertemplate
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: OLVMClusterTemplate is the Schema for the OLVMClusterTemplates
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OLVMClusterTemplateSpec defines the desired state of OLVMClusterTemplate.
+            properties:
+              template:
+                description: OLVMClusterTemplateResource specifies the resource that
+                  the template creates
+                properties:
+                  metadata:
+                    description: |-
+                      Standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    type: object
+                  spec:
+                    description: OLVMClusterSpec defines the specification for a OLVMCluster
+                      resource.
+                    properties:
+                      controlPlaneEndpoint:
+                        description: ControlPlaneEndpoint specifies the Kubernetes
+                          control plane endpoint.
+                        properties:
+                          host:
+                            description: Host is the endpoint host name or IP address.
+                            type: string
+                          port:
+                            description: Port is the endpoint port.
+                            format: int32
+                            type: integer
+                        required:
+                        - host
+                        - port
+                        type: object
+                      olvmDatacenterName:
+                        description: OlvmDatacenterName is the datacenter where the
+                          Kubernetes cluster will be created.
+                        type: string
+                      olvmOvirtAPIServer:
+                        description: OlvmOvirtAPIServer contains the information needed
+                          to use the OLVM oVirt REST API server.
+                        properties:
+                          caConfigMap:
+                            description: |-
+                              CAConfigMap is the namespaced name of the ConfigMap which has the CA.CRT for the OLVM endpoint.
+                              For example: https://example.com/ovirt-engine
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          credentialsSecret:
+                            description: CredentialsSecretName is the namespaced name
+                              of the Secret which has the credentials needed to access
+                              the OLVM endpoint.
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          insecureSkipTLSVerify:
+                            description: InsecureSkipTLSVerify skips OLVM TLS certificate
+                              verification.
+                            type: boolean
+                          serverURL:
+                            description: ServerURL is the OLVM oVirt REST API endpoint
+                              URL.
+                            type: string
+                        required:
+                        - credentialsSecret
+                        - serverURL
+                        type: object
+                    required:
+                    - controlPlaneEndpoint
+                    - olvmDatacenterName
+                    - olvmOvirtAPIServer
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/charts/olvm-capi-1.0.0/crds/infrastructure.cluster.x-k8s.io_olvmmachines.yaml
+++ b/charts/olvm-capi-1.0.0/crds/infrastructure.cluster.x-k8s.io_olvmmachines.yaml
@@ -1,0 +1,369 @@
+# Copyright (c) 2024, 2025, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-olvm
+    cluster.x-k8s.io/v1beta1: v1
+  name: olvmmachines.infrastructure.cluster.x-k8s.io
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: OLVMMachine
+    listKind: OLVMMachineList
+    plural: olvmmachines
+    shortNames:
+    - olvmm
+    singular: olvmmachine
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: True if the OlvmCluster is ready
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: The age of the OlvmCluster
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: The VM memory size
+      jsonPath: .spec.virtualMachine.memory
+      name: Memory
+      priority: 2
+      type: string
+    - description: The number of VM CPU cores
+      jsonPath: .spec.virtualMachine.cpu.topology.cores
+      name: Cores
+      priority: 2
+      type: string
+    - description: The number of VM CPU sockets
+      jsonPath: .spec.virtualMachine.cpu.topology.sockets
+      name: Sockets
+      priority: 2
+      type: string
+    - description: The OLVM VM status
+      jsonPath: .status.olvm.virtualMachine.status
+      name: VMStatus
+      priority: 2
+      type: string
+    - description: The OLVM VM IP Address
+      jsonPath: .status.olvm.ipAddress
+      name: VMIPAddress
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: OLVMMachine specifies am OLVMMachine instance.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OLVMMachineSpec defines the specification for a OLVMMachine
+              resource.
+            properties:
+              olvmNetwork:
+                description: Network is the OLVM network configuration.
+                properties:
+                  networkName:
+                    description: NetworkName is the name of an existing OLVM network.
+                    type: string
+                  vnicName:
+                    description: VnicName is the name of OLVM vnic. Default is nic1.
+                    type: string
+                  vnicProfileName:
+                    description: VnicProfileName is the name of an existing OLVM vnic
+                      profile.
+                    type: string
+                required:
+                - networkName
+                - vnicProfileName
+                type: object
+              olvmOvirtClusterName:
+                description: OlvmOvirtClusterName is the OLVM cluster name.
+                type: string
+              providerID:
+                description: |-
+                  ProviderID is the identifier for the provider’s machine instance.
+                  This field is set by the controller
+                  ProviderID is expected to match the value set by the KCM cloud provider in the Nodes.
+                  The Machine controller bubbles it up to the Machine CR, and it’s used to find the matching Node.
+                  Any other consumers can use the providerID as the source of truth to match both Machines and Nodes.
+                type: string
+              virtualMachine:
+                description: VMSpec is the VM configuration.
+                properties:
+                  cpu:
+                    description: Cpu is the VM CPU configuration.
+                    properties:
+                      architecture:
+                        description: Architecture is the CPU architecture. Default
+                          is x86_64.
+                        type: string
+                      topology:
+                        description: Topology is the CPU topology.
+                        properties:
+                          cores:
+                            description: Cores is the number of CPU cores. Default
+                              is 2.
+                            format: int32
+                            type: integer
+                          sockets:
+                            description: Sockets is the number of CPU sockets. Default
+                              is 2.
+                            format: int32
+                            type: integer
+                          threads:
+                            description: Threads is the number of CPU threads. Default
+                              is 1.
+                            format: int32
+                            type: integer
+                        type: object
+                    type: object
+                  memory:
+                    description: 'Memory is the memory size of the VM.  For example:
+                      7GB.'
+                    type: string
+                  network:
+                    description: VMNetwork is the VM network configuration.
+                    properties:
+                      gateway:
+                        description: Gateway is the VM gateway. Default is the .1
+                          address of the subnet.
+                        type: string
+                      interface:
+                        description: Interface is the network interface. Default is
+                          enp1s0.
+                        type: string
+                      interfaceType:
+                        description: InterfaceType is the network interface type.
+                          Default is virtio.
+                        type: string
+                      ipv4:
+                        description: IPV4 is the IPV4 configuration. Required if IPV6
+                          is nil
+                        properties:
+                          ipAddresses:
+                            description: |-
+                              IpAddresses is a list of addresses used by the VMs.  These can be CIDR blocks, individual addresses, or a range.
+                              The following are valid. Ranges are inclusive:
+                                10.1.2.0/30
+                                10.1.2.10-10.1.2.20
+                                10.1.2.27
+                            items:
+                              type: string
+                            type: array
+                          subnet:
+                            description: subnet CIDR.
+                            type: string
+                        required:
+                        - ipAddresses
+                        - subnet
+                        type: object
+                      ipv6:
+                        description: IPV6 is the IPV6 configuration. Required if IPV4
+                          is nil
+                        properties:
+                          ipAddresses:
+                            description: |-
+                              IpAddresses is a list of addresses used by the VMs.  These can be CIDR blocks, individual addresses, or a range.
+                              The following are valid. Ranges are inclusive:
+                                10.1.2.0/30
+                                10.1.2.10-10.1.2.20
+                                10.1.2.27
+                            items:
+                              type: string
+                            type: array
+                          subnet:
+                            description: subnet CIDR.
+                            type: string
+                        required:
+                        - ipAddresses
+                        - subnet
+                        type: object
+                    type: object
+                required:
+                - memory
+                - network
+                type: object
+              vmTemplateName:
+                description: VMTemplateName is the name of the OLVM VM template used
+                  to create a VM.
+                type: string
+            required:
+            - olvmNetwork
+            - virtualMachine
+            - vmTemplateName
+            type: object
+          status:
+            description: OLVMMachineStatus defines the status OLVMMachine resource.
+            properties:
+              addresses:
+                description: |-
+                  MachineAddress is a list of the host names, external IP addresses, pkg IP addresses,
+                  external DNS names, and/or pkg DNS names for the provider’s machine instance
+                items:
+                  description: MachineAddress is the address of the machine
+                  properties:
+                    address:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - address
+                  - type
+                  type: object
+                type: array
+              conditions:
+                description: Conditions are the list of conditions for the OLVMMachine.
+                items:
+                  description: MachineCondition describes the current condition of
+                    the OLVMMachine.
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time the condition
+                        transitioned from one status to another.
+                      type: string
+                    message:
+                      description: Message is a human-readable message indicating
+                        details about the last transition.
+                      type: string
+                    reason:
+                      description: Reason for the condition.  This is a machine-readable
+                        one word value.
+                      type: string
+                    status:
+                      description: 'Status of the condition: one of `True`, `False`,
+                        or `Unknown`.'
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureDomains:
+                additionalProperties:
+                  description: FailureDomainSpec specifies a failuredomain
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: Attributes are arbitrary attributes for users to
+                        apply to a failure domain.
+                      type: object
+                    controlPlane:
+                      description: ControlPlane indicates if failure domain is appropriate
+                        for running control plane instances.
+                      type: boolean
+                  required:
+                  - controlPlane
+                  type: object
+                description: |-
+                  FailureDomains is the failure domains that machines should be placed in.
+                  The maputil key is the FailureDomain name
+                type: object
+              failureMessage:
+                description: |-
+                  FailureMessage indicates there is a fatal problem reconciling the provider’s infrastructure;
+                  meant to be a more descriptive value than failureReason
+                type: string
+              failureReason:
+                description: |-
+                  FailureReason indicates there is a fatal problem reconciling the provider’s infrastructure;
+                  meant to be suitable for programmatic interpretation
+                type: string
+              lastObservedGeneration:
+                description: |-
+                  LastObservedGeneration is the latest generation of the OLVMMachine
+                  that the controller_foundation has seen, but not necessarily reconciled.
+                format: int64
+                type: integer
+              lastSuccessfulGeneration:
+                description: LastSuccessfulGeneration is the last generation of the
+                  OLVMMachine that was successfully reconciled.
+                format: int64
+                type: integer
+              olvm:
+                properties:
+                  clusterID:
+                    type: string
+                  clusterName:
+                    type: string
+                  ipAddress:
+                    type: string
+                  networkID:
+                    type: string
+                  networkName:
+                    type: string
+                  virtualMachine:
+                    properties:
+                      createRequestSubmitted:
+                        type: boolean
+                      creationError:
+                        type: string
+                      creationStatus:
+                        type: string
+                      lastGeneration:
+                        type: string
+                      status:
+                        type: string
+                      vmID:
+                        type: string
+                      vmName:
+                        type: string
+                    type: object
+                  vmTemplateID:
+                    type: string
+                  vmTemplateName:
+                    type: string
+                  vnicID:
+                    type: string
+                  vnicName:
+                    type: string
+                  vnicProfileID:
+                    type: string
+                  vnicProfileName:
+                    type: string
+                required:
+                - virtualMachine
+                type: object
+              ready:
+                description: Ready indicates the provider-specific infrastructure
+                  has been provisioned and is ready
+                type: boolean
+            required:
+            - olvm
+            - ready
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/olvm-capi-1.0.0/crds/infrastructure.cluster.x-k8s.io_olvmmachinetemplates.yaml
+++ b/charts/olvm-capi-1.0.0/crds/infrastructure.cluster.x-k8s.io_olvmmachinetemplates.yaml
@@ -1,0 +1,208 @@
+# Copyright (c) 2024, 2025, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-olvm
+    cluster.x-k8s.io/v1beta1: v1
+  name: olvmmachinetemplates.infrastructure.cluster.x-k8s.io
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: OLVMMachineTemplate
+    listKind: OLVMMachineTemplateList
+    plural: olvmmachinetemplates
+    shortNames:
+    - olvmmt
+    singular: olvmmachinetemplate
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: OLVMMachineTemplate is the Schema for the OLVMMachineTemplates
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OLVMMachineTemplateSpec defines the desired state of OLVMMachineTemplate.
+            properties:
+              template:
+                description: OLVMMachineTemplateResource specifies the resource that
+                  the template creates
+                properties:
+                  metadata:
+                    description: |-
+                      Standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    type: object
+                  spec:
+                    description: OLVMMachineSpec defines the specification for a OLVMMachine
+                      resource.
+                    properties:
+                      olvmNetwork:
+                        description: Network is the OLVM network configuration.
+                        properties:
+                          networkName:
+                            description: NetworkName is the name of an existing OLVM
+                              network.
+                            type: string
+                          vnicName:
+                            description: VnicName is the name of OLVM vnic. Default
+                              is nic1.
+                            type: string
+                          vnicProfileName:
+                            description: VnicProfileName is the name of an existing
+                              OLVM vnic profile.
+                            type: string
+                        required:
+                        - networkName
+                        - vnicProfileName
+                        type: object
+                      olvmOvirtClusterName:
+                        description: OlvmOvirtClusterName is the OLVM cluster name.
+                        type: string
+                      providerID:
+                        description: |-
+                          ProviderID is the identifier for the provider’s machine instance.
+                          This field is set by the controller
+                          ProviderID is expected to match the value set by the KCM cloud provider in the Nodes.
+                          The Machine controller bubbles it up to the Machine CR, and it’s used to find the matching Node.
+                          Any other consumers can use the providerID as the source of truth to match both Machines and Nodes.
+                        type: string
+                      virtualMachine:
+                        description: VMSpec is the VM configuration.
+                        properties:
+                          cpu:
+                            description: Cpu is the VM CPU configuration.
+                            properties:
+                              architecture:
+                                description: Architecture is the CPU architecture.
+                                  Default is x86_64.
+                                type: string
+                              topology:
+                                description: Topology is the CPU topology.
+                                properties:
+                                  cores:
+                                    description: Cores is the number of CPU cores.
+                                      Default is 2.
+                                    format: int32
+                                    type: integer
+                                  sockets:
+                                    description: Sockets is the number of CPU sockets.
+                                      Default is 2.
+                                    format: int32
+                                    type: integer
+                                  threads:
+                                    description: Threads is the number of CPU threads.
+                                      Default is 1.
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          memory:
+                            description: 'Memory is the memory size of the VM.  For
+                              example: 7GB.'
+                            type: string
+                          network:
+                            description: VMNetwork is the VM network configuration.
+                            properties:
+                              gateway:
+                                description: Gateway is the VM gateway. Default is
+                                  the .1 address of the subnet.
+                                type: string
+                              interface:
+                                description: Interface is the network interface. Default
+                                  is enp1s0.
+                                type: string
+                              interfaceType:
+                                description: InterfaceType is the network interface
+                                  type. Default is virtio.
+                                type: string
+                              ipv4:
+                                description: IPV4 is the IPV4 configuration. Required
+                                  if IPV6 is nil
+                                properties:
+                                  ipAddresses:
+                                    description: |-
+                                      IpAddresses is a list of addresses used by the VMs.  These can be CIDR blocks, individual addresses, or a range.
+                                      The following are valid. Ranges are inclusive:
+                                        10.1.2.0/30
+                                        10.1.2.10-10.1.2.20
+                                        10.1.2.27
+                                    items:
+                                      type: string
+                                    type: array
+                                  subnet:
+                                    description: subnet CIDR.
+                                    type: string
+                                required:
+                                - ipAddresses
+                                - subnet
+                                type: object
+                              ipv6:
+                                description: IPV6 is the IPV6 configuration. Required
+                                  if IPV4 is nil
+                                properties:
+                                  ipAddresses:
+                                    description: |-
+                                      IpAddresses is a list of addresses used by the VMs.  These can be CIDR blocks, individual addresses, or a range.
+                                      The following are valid. Ranges are inclusive:
+                                        10.1.2.0/30
+                                        10.1.2.10-10.1.2.20
+                                        10.1.2.27
+                                    items:
+                                      type: string
+                                    type: array
+                                  subnet:
+                                    description: subnet CIDR.
+                                    type: string
+                                required:
+                                - ipAddresses
+                                - subnet
+                                type: object
+                            type: object
+                        required:
+                        - memory
+                        - network
+                        type: object
+                      vmTemplateName:
+                        description: VMTemplateName is the name of the OLVM VM template
+                          used to create a VM.
+                        type: string
+                    required:
+                    - olvmNetwork
+                    - virtualMachine
+                    - vmTemplateName
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/charts/olvm-capi-1.0.0/templates/_helpers.tpl
+++ b/charts/olvm-capi-1.0.0/templates/_helpers.tpl
@@ -1,0 +1,54 @@
+# Copyright (c) 2024, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "olvm-capi.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "olvm-capi.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "olvm-capi.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "olvm-capi.labels" -}}
+helm.sh/chart: {{ include "olvm-capi.chart" . }}
+{{ include "olvm-capi.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "olvm-capi.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "olvm-capi.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/olvm-capi-1.0.0/templates/deployment.yaml
+++ b/charts/olvm-capi-1.0.0/templates/deployment.yaml
@@ -1,0 +1,90 @@
+# Copyright (c) 2024, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "olvm-capi.fullname" . }}-controller-manager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-olvm
+    clusterctl.cluster.x-k8s.io: ""
+    control-plane: controller-manager
+  {{- include "olvm-capi.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.controllerManager.replicas }}
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/provider: infrastructure-olvm
+      control-plane: controller-manager
+    {{- include "olvm-capi.selectorLabels" . | nindent 6 }}
+  {{- with .Values.controllerManager.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: infrastructure-olvm
+        control-plane: controller-manager
+      {{- include "olvm-capi.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+      - name: controller-manager
+        args: {{- toYaml .Values.controllerManager.container.args | nindent 8 }}
+        command:
+        - /olvm-capi-controller-manager
+        env:
+        {{ if .Values.proxy.httpsProxy }}
+        - name: https_proxy
+          value: {{ quote .Values.proxy.httpsProxy }}
+        {{ end }}
+        {{ if .Values.proxy.httpProxy }}
+        - name: http_proxy
+          value: {{ quote .Values.proxy.httpProxy }}
+        {{ end }}
+        {{ if .Values.proxy.noProxy }}
+        - name: no_proxy
+          value: {{ quote .Values.proxy.noProxy }}
+        {{ end }}
+        image: {{ .Values.controllerManager.container.image.repository}}:{{ .Values.controllerManager.container.image.tag }}
+        imagePullPolicy: {{ .Values.controllerManager.container.imagePullPolicy }}
+#        livenessProbe:
+#          httpGet:
+#            path: /healthz
+#            port: healthz
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        - containerPort: 9440
+          name: healthz
+          protocol: TCP
+        - containerPort: {{ .Values.metricsPort }}
+          name: metrics
+          protocol: TCP
+#        readinessProbe:
+#          httpGet:
+#            path: /readyz
+#            port: healthz
+        resources:
+          {{- toYaml .Values.controllerManager.container.resources | nindent 12 }}
+        securityContext:
+          {{- toYaml .Values.controllerManager.container.containerSecurityContext | nindent 12 }}
+        terminationMessagePolicy: FallbackToLogsOnError
+      securityContext:
+        {{- toYaml .Values.controllerManager.podSecurityContext | nindent 8 }}
+      serviceAccountName: {{ include "olvm-capi.fullname" . }}-controller-manager
+      terminationGracePeriodSeconds: 0
+      {{- with .Values.controllerManager.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controllerManager.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controllerManager.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/olvm-capi-1.0.0/templates/metrics-reader-rbac.yaml
+++ b/charts/olvm-capi-1.0.0/templates/metrics-reader-rbac.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) 2024, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "olvm-capi.fullname" . }}-metrics-reader
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-olvm
+    clusterctl.cluster.x-k8s.io: ""
+  {{- include "olvm-capi.labels" . | nindent 4 }}
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/charts/olvm-capi-1.0.0/templates/metrics-service.yaml
+++ b/charts/olvm-capi-1.0.0/templates/metrics-service.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2024, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "olvm-capi.fullname" . }}-controller-manager-metrics-service
+  namespace: {{ .Release.Namespace }}
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-olvm
+    clusterctl.cluster.x-k8s.io: ""
+    control-plane: controller-manager
+  {{- include "olvm-capi.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.metricsService.type }}
+  selector:
+    cluster.x-k8s.io/provider: infrastructure-olvm
+    control-plane: controller-manager
+  {{- include "olvm-capi.selectorLabels" . | nindent 4 }}
+  ports:
+	{{- .Values.metricsService.ports | toYaml | nindent 2 }}

--- a/charts/olvm-capi-1.0.0/templates/mutating-webhook-configuration.yaml
+++ b/charts/olvm-capi-1.0.0/templates/mutating-webhook-configuration.yaml
@@ -1,0 +1,35 @@
+# Copyright (c) 2024, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+{{- if .Values.webhooksEnabled }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: {{ include "olvm-capi.fullname" . }}-mutating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "olvm-capi.fullname" . }}-serving-cert
+  labels:
+  {{- include "olvm-capi.labels" . | nindent 4 }}
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: '{{ include "olvm-capi.fullname" . }}-webhook-service'
+      namespace: '{{ .Release.Namespace }}'
+      path: /mutate-infrastructure-cluster-x-k8s-io-v1beta1-olvmcluster
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.olvmcluster.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - olvmclusters
+  sideEffects: None
+  {{- end }}

--- a/charts/olvm-capi-1.0.0/templates/operator-rbac.yaml
+++ b/charts/olvm-capi-1.0.0/templates/operator-rbac.yaml
@@ -1,0 +1,144 @@
+# Copyright (c) 2024, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "olvm-capi.fullname" . }}-controller-manager-role
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-olvm
+    clusterctl.cluster.x-k8s.io: ""
+  {{- include "olvm-capi.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - olvmclusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - olvmclusters/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - olvmclusters/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - olvmmachines
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - olvmmachines/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - olvmmachines/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machines
+  - machines/status
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - clusters/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinepools
+  - machinepools/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+    - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "olvm-capi.fullname" . }}-controller-manager-rolebinding
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-olvm
+    clusterctl.cluster.x-k8s.io: ""
+  {{- include "olvm-capi.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: '{{ include "olvm-capi.fullname" . }}-controller-manager-role'
+subjects:
+- kind: ServiceAccount
+  name: '{{ include "olvm-capi.fullname" . }}-controller-manager'
+  namespace: '{{ .Release.Namespace }}'

--- a/charts/olvm-capi-1.0.0/templates/selfsigned-issuer.yaml
+++ b/charts/olvm-capi-1.0.0/templates/selfsigned-issuer.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2024, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "olvm-capi.fullname" . }}-selfsigned-issuer
+  namespace: {{ .Release.Namespace }}
+  labels:
+  {{- include "olvm-capi.labels" . | nindent 4 }}
+spec:
+  selfSigned: {}

--- a/charts/olvm-capi-1.0.0/templates/serviceaccount.yaml
+++ b/charts/olvm-capi-1.0.0/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) 2024, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "olvm-capi.fullname" . }}-controller-manager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-olvm
+    clusterctl.cluster.x-k8s.io: ""
+  {{- include "olvm-capi.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.controllerManager.serviceAccount.annotations | nindent 4 }}

--- a/charts/olvm-capi-1.0.0/templates/serving-cert.yaml
+++ b/charts/olvm-capi-1.0.0/templates/serving-cert.yaml
@@ -1,0 +1,19 @@
+# Copyright (c) 2024, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "olvm-capi.fullname" . }}-serving-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+  {{- include "olvm-capi.labels" . | nindent 4 }}
+spec:
+  dnsNames:
+  - '{{ include "olvm-capi.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc'
+  - '{{ include "olvm-capi.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc.{{
+    .Values.kubernetesClusterDomain }}'
+  issuerRef:
+    kind: Issuer
+    name: '{{ include "olvm-capi.fullname" . }}-selfsigned-issuer'
+  secretName: {{ include "olvm-capi.fullname" . }}-webhook-service-cert

--- a/charts/olvm-capi-1.0.0/templates/validating-webhook-configuration.yaml
+++ b/charts/olvm-capi-1.0.0/templates/validating-webhook-configuration.yaml
@@ -1,0 +1,98 @@
+# Copyright (c) 2024, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+{{- if .Values.webhooksEnabled }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: {{ include "olvm-capi.fullname" . }}-validating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "olvm-capi.fullname" . }}-serving-cert
+  labels:
+  {{- include "olvm-capi.labels" . | nindent 4 }}
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: '{{ include "olvm-capi.fullname" . }}-webhook-service'
+      namespace: '{{ .Release.Namespace }}'
+      path: /validate-infrastructure-cluster-x-k8s-io-v1beta1-olvmcluster
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.olvmcluster.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - olvmclusters
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: '{{ include "olvm-capi.fullname" . }}-webhook-service'
+      namespace: '{{ .Release.Namespace }}'
+      path: /validate-infrastructure-cluster-x-k8s-io-v1beta1-olvmmachine
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.olvmmachine.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - olvmmachine
+  sideEffects: None
+- admissionReviewVersions:
+    - v1beta1
+  clientConfig:
+    service:
+      name: '{{ include "olvm-capi.fullname" . }}-webhook-service'
+      namespace: '{{ .Release.Namespace }}'
+      path: /validate-infrastructure-cluster-x-k8s-io-v1beta1-olvmmachinetemplate
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.olvmmachinetemplate.infrastructure.cluster.x-k8s.io
+  rules:
+    - apiGroups:
+        - infrastructure.cluster.x-k8s.io
+      apiVersions:
+        - v1beta1
+      operations:
+        - CREATE
+        - UPDATE
+      resources:
+        - olvmmachinetemplates
+  sideEffects: None
+- admissionReviewVersions:
+    - v1beta1
+  clientConfig:
+    service:
+      name: '{{ include "olvm-capi.fullname" . }}-webhook-service'
+      namespace: '{{ .Release.Namespace }}'
+      path: /validate-infrastructure-cluster-x-k8s-io-v1beta1-olvmclustertemplate
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.olvmclustertemplate.infrastructure.cluster.x-k8s.io
+  rules:
+    - apiGroups:
+        - infrastructure.cluster.x-k8s.io
+      apiVersions:
+        - v1beta1
+      operations:
+        - CREATE
+        - UPDATE
+      resources:
+        - olvmclustertemplates
+  sideEffects: None
+  {{- end }}

--- a/charts/olvm-capi-1.0.0/templates/webhook-service.yaml
+++ b/charts/olvm-capi-1.0.0/templates/webhook-service.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2024, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+{{- if .Values.webhooksEnabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "olvm-capi.fullname" . }}-webhook-service
+  namespace: {{ .Release.Namespace }}
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-olvm
+    clusterctl.cluster.x-k8s.io: ""
+  {{- include "olvm-capi.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.webhookService.type }}
+  selector:
+    cluster.x-k8s.io/provider: infrastructure-olvm
+  {{- include "olvm-capi.selectorLabels" . | nindent 4 }}
+  ports:
+	{{- .Values.webhookService.ports | toYaml | nindent 2 }}
+  {{- end }}

--- a/charts/olvm-capi-1.0.0/values.yaml
+++ b/charts/olvm-capi-1.0.0/values.yaml
@@ -23,7 +23,7 @@ controllerManager:
     - -zap-stacktrace-level=error
     - -zap-time-encoding=epoch
     image:
-      repository: olcne/cluster-api-olvm-controller-manager
+      repository: ghcr.io/oracle-cne/cluster-api-olvm-controller-manager
       tag: v1.0.0
     imagePullPolicy: IfNotPresent
     containerSecurityContext:

--- a/charts/olvm-capi-1.0.0/values.yaml
+++ b/charts/olvm-capi-1.0.0/values.yaml
@@ -1,0 +1,90 @@
+# Copyright (c) 2024, 2025, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+nameOverride:
+fullnameOverride: olvm-capi
+
+logLevel: info
+
+metricsPort: 8443
+
+# Temporary value
+webhooksEnabled: false
+
+kubernetesClusterDomain: cluster.local
+
+controllerManager:
+  container:
+    args:
+    - -cert-dir=/etc/webhook/certs
+    - -metrics-addr=127.0.0.1:8443
+    - -zap-log-level=info
+    - -zap-encoder=json
+    - -zap-stacktrace-level=error
+    - -zap-time-encoding=epoch
+    image:
+      repository: olcne/cluster-api-olvm-controller-manager
+      tag: v1.0.0
+    imagePullPolicy: IfNotPresent
+    containerSecurityContext:
+      privileged: false
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsGroup: 65532
+      runAsUser: 65532
+    resources:
+      requests:
+        memory: 128Mi
+  replicas: 1
+  serviceAccount:
+    annotations: {}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  podSecurityContext:
+    runAsUser: 1000
+    runAsGroup: 999
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - preference:
+          matchExpressions:
+          - key: node-role.kubernetes.io/control-plane
+            operator: Exists
+        weight: 10
+      - preference:
+          matchExpressions:
+          - key: node-role.kubernetes.io/master
+            operator: Exists
+        weight: 10
+  imagePullSecrets: []
+
+metricsService:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  type: ClusterIP
+
+webhookService:
+  ports:
+  - port: 443
+    targetPort: webhook-server
+  type: ClusterIP
+
+proxy:
+  httpsProxy:
+  httpProxy:
+  noProxy:


### PR DESCRIPTION
Add olvm capi chart to the catalog.  This is needed to provision and OLVM CAPI cluster using ocne CLI.

Cluster start
```
ocne cluster start  --provider olvm -c ~/.ocne/olvm-paul.yaml 
INFO[2025-05-01T14:53:53-04:00] Installing cert-manager into cert-manager: ok 
INFO[2025-05-01T14:53:53-04:00] Installing core-capi into capi-system: ok 
INFO[2025-05-01T14:53:54-04:00] Installing olvm-capi into cluster-api-provider-olvm: ok 
INFO[2025-05-01T14:53:54-04:00] Installing bootstrap-capi into capi-kubeadm-bootstrap-system: ok 
INFO[2025-05-01T14:53:55-04:00] Installing control-plane-capi into capi-kubeadm-control-plane-system: ok 
INFO[2025-05-01T14:53:55-04:00] Waiting for Core Cluster API Controllers: ok 
INFO[2025-05-01T14:53:55-04:00] Waiting for Kubadm Boostrap Cluster API Controllers: ok 
INFO[2025-05-01T14:53:55-04:00] Waiting for Kubadm Control Plane Cluster API Controllers: ok 
INFO[2025-05-01T14:53:55-04:00] Waiting for Olvm Cluster API Controllers: ok 
INFO[2025-05-01T14:53:55-04:00] Applying Cluster API resources               
INFO[2025-05-01T14:53:57-04:00] Waiting for kubeconfig: ok       
INFO[2025-05-01T14:56:31-04:00] Waiting for the Kubernetes cluster to be ready: ok 
INFO[2025-05-01T14:56:31-04:00] Installing applications into workload cluster 
INFO[2025-05-01T14:56:38-04:00] Installing ovirt-csi-driver into ovirt-csi: ok 
INFO[2025-05-01T14:56:41-04:00] Installing core-dns into kube-system: ok 
INFO[2025-05-01T14:56:44-04:00] Installing kube-proxy into kube-system: ok 
INFO[2025-05-01T14:56:48-04:00] Installing kubernetes-gateway-api-crds into kube-system: ok 
INFO[2025-05-01T14:56:51-04:00] Installing flannel into kube-flannel: ok 
INFO[2025-05-01T14:56:54-04:00] Installing ui into ocne-system: ok 
INFO[2025-05-01T14:56:57-04:00] Installing ocne-catalog into ocne-system: ok 
INFO[2025-05-01T14:56:57-04:00] Kubernetes cluster was created successfully  
INFO[2025-05-01T14:57:04-04:00] Waiting for the UI to be ready: waiting... 
```