### PR TITLE
Update headlamp version to 0.40.1 in ui-2.3.0 charts

### DIFF
--- a/charts/ui-2.3.0/templates/deployment.yaml
+++ b/charts/ui-2.3.0/templates/deployment.yaml
@@ -261,11 +261,11 @@ spec:
             {{- with .Values.config.extraArgs }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
-            {{- with .Values.config.tlsCert }}
-            - "-tls-cert={{ . }}"
+            {{- with .Values.config.tlsCertPath }}
+            - "-tls-cert-path={{ . }}"
             {{- end }}
-            {{- with .Values.config.tlsKey }}
-            - "-tls-key={{ . }}"
+            {{- with .Values.config.tlsKeyPath }}
+            - "-tls-key-path={{ . }}"
             {{- end }}
           ports:
             - name: https

--- a/charts/ui-2.3.0/values.yaml
+++ b/charts/ui-2.3.0/values.yaml
@@ -13,7 +13,7 @@ image:
   # -- Image pull policy. One of Always, Never, IfNotPresent
   pullPolicy: IfNotPresent
   # -- Container image tag, If "" uses appVersion in Chart.yaml
-  tag: "v0.35.0"
+  tag: "v0.40.1"
 
 # -- An optional list of references to secrets in the same namespace to use for pulling any of the images used
 imagePullSecrets: []
@@ -101,8 +101,8 @@ config:
   pluginsDir: "/build/plugins"
   enableHelm: true
   watchPlugins: false
-  tlsCert: "/headlamp-cert/headlamp-ca.crt"
-  tlsKey: "/headlamp-cert/headlamp-tls.key"
+  tlsCertPath: "/headlamp-cert/headlamp-ca.crt"
+  tlsKeyPath: "/headlamp-cert/headlamp-tls.key"
   # Extra arguments that can be given to the container. See charts/headlamp/README.md for more information.
   extraArgs: []
 


### PR DESCRIPTION
Add UI-2.4.0 helm charts.
```
Headlamp version: v0.40.1
app-catalog plugin version : 0.8.0
prometheus plugin version: 0.8.2
```
