### PR TITLE
Rook 1.18.0: ceph-csi-controller-manager pod stuck "CreateContainerError" when newly deploy in an existing cluster

### DIFF
--- a/charts/rook-1.18.0/charts/ceph-csi-operator/values.yaml
+++ b/charts/rook-1.18.0/charts/ceph-csi-operator/values.yaml
@@ -19,7 +19,7 @@ controllerManager:
       watchNamespace: ""
     image:
       repository: olcne/ceph-csi-operator
-      tag: v0.4.0
+      tag: v0.4.1
     resources:
       limits:
         cpu: 500m


### PR DESCRIPTION
updated to fixed image of ceph-csi-operator