### PR TITLE
Bump specfile release

### DIFF
--- a/buildrpm/ocne-catalog-container-image.spec
+++ b/buildrpm/ocne-catalog-container-image.spec
@@ -7,7 +7,7 @@
 
 Name:		%{_name}-container-image
 Version:	2.0.0
-Release:	31%{?dist}
+Release:	32%{?dist}
 Summary:	An on-disk Helm chart repository
 
 Group:		Development/Tools
@@ -37,6 +37,9 @@ docker save -o %{_name}.tar %{docker_tag}
 %clean
 
 %changelog
+* Thu Mar 26 2026 Prasad Shirodkar <prasad.shirodkar@oracle.com> - 2.0.0-32
+- Removed duplicate labels in the oVirt CSI Driver chart.
+
 * Fri Dec 12 2025 Daniel Krasinski <daniel.krasinski@oracle.com> - 2.0.0-31
 - Added HA Monitor application for managing keepalived/nginx configuration with VIP based deployments
 

--- a/buildrpm/ocne-catalog.spec
+++ b/buildrpm/ocne-catalog.spec
@@ -3,7 +3,7 @@
 
 Name:		ocne-catalog
 Version:	2.0.0
-Release:	31%{?dist}
+Release:	32%{?dist}
 Summary:	An on-disk Helm chart repository
 
 Group:		Development/Tools
@@ -37,6 +37,9 @@ cp -ap olm/icons/* %{buildroot}/opt/icons
 /opt/icons
 
 %changelog
+* Thu Mar 26 2026 Prasad Shirodkar <prasad.shirodkar@oracle.com> - 2.0.0-32
+- Removed duplicate labels in the oVirt CSI Driver chart.
+
 * Fri Dec 12 2025 Daniel Krasinski <daniel.krasinski@oracle.com> - 2.0.0-31
 - Added HA Monitor application for managing keepalived/nginx configuration with VIP based deployments
 

--- a/olm/jenkins/ci/Jenkinsfile
+++ b/olm/jenkins/ci/Jenkinsfile
@@ -7,7 +7,7 @@ String container_registry_namespace = "olcne"
 String registry = "container-registry.oracle.com/" + container_registry_namespace
 
 olcnePipeline(
-    branchPattern: new BranchPattern(master: '(master|release/.*)', feature: '(?!^master$)(?!^release/.*$)(^.*$)'),
+    branchPattern: new BranchPattern(master: 'release/.*', feature: '(?!^release/.*$)(^.*$)'),
     containers: [(registry + '/ocne-catalog:' + imageTag) : container_registry_namespace + '/ocne-catalog:' + imageTag],
     architectures: ['x86_64', 'aarch64'],
     platforms: ['ol8'],


### PR DESCRIPTION
Bumps the specfile release numbers so that the build can succeed.

## Container Images
- container-registry.oracle.com/olcne/ocne-catalog:v2.0.0