### PR TITLE
ovirt-csi-driver: Update ovirt-csi-driver-4.21.0 to add Kubernetes 1.34/1.35 support

### DIFF
--- a/charts/ovirt-csi-driver-4.21.0/Chart.yaml
+++ b/charts/ovirt-csi-driver-4.21.0/Chart.yaml
@@ -5,4 +5,4 @@ type: application
 version: 4.21.0
 appVersion: "4.21.0"
 icon: icons/kubernetes-logo.svg
-kubeVersion: '>= 1.30.0 < 1.34.0'
+kubeVersion: '>= 1.30.0 < 1.36.0'


### PR DESCRIPTION
## What
- Expanded `kubeVersion` range in Chart.yaml to include Kubernetes 1.34 and 1.35 for ovirt-csi-driver 4.21.0

## Why
- Enable deployment on newer Kubernetes versions (1.34, 1.35)

## Changes
- Updated `kubeVersion` from <old-range> to `>= 1.30.0 < 1.36.0`

