### PR TITLE
Bump CSI sidecars for ovirt-csi-drvier

### DIFF
--- a/charts/ovirt-csi-driver-4.21.1/values.yaml
+++ b/charts/ovirt-csi-driver-4.21.1/values.yaml
@@ -4,7 +4,7 @@ csiController:
       privileged: true
     image:
       repository: olcne/csi-attacher
-      tag: v4.10.0
+      tag: v4.12.0
     resources:
       limits:
         cpu: 160m
@@ -17,7 +17,7 @@ csiController:
       privileged: true
     image:
       repository: olcne/csi-provisioner
-      tag: v6.0.0
+      tag: v6.3.0
     resources:
       limits:
         cpu: 160m
@@ -30,7 +30,7 @@ csiController:
       privileged: true
     image:
       repository: olcne/csi-resizer
-      tag: v1.14.0
+      tag: v2.2.0
     resources:
       limits:
         cpu: 160m
@@ -41,7 +41,7 @@ csiController:
   livenessProbe:
     image:
       repository: olcne/livenessprobe
-      tag: v2.17.0
+      tag: v2.19.0
     resources:
       limits:
         cpu: 160m
@@ -83,7 +83,7 @@ csiNode:
   csiDriverRegistrar:
     image:
       repository: olcne/csi-node-driver-registrar
-      tag: v2.15.0
+      tag: v2.17.0
     resources:
       limits:
         cpu: 160m
@@ -94,7 +94,7 @@ csiNode:
   livenessProbe:
     image:
       repository: olcne/livenessprobe
-      tag: v2.17.0
+      tag: v2.19.0
     resources:
       limits:
         cpu: 160m


### PR DESCRIPTION
Update CSI sidecars for ovirt-csi-driver

## Container Images
- container-registry.oracle.com/olcne/ocne-catalog:v2.0.0